### PR TITLE
Add generic lobby movement and stop-on-game logic

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
@@ -1,6 +1,8 @@
 package best.spaghetcodes.kira.bot
 
 import best.spaghetcodes.kira.kira
+import best.spaghetcodes.kira.bot.player.LobbyMovement
+import best.spaghetcodes.kira.bot.bots.Sumo
 import net.minecraftforge.client.event.ClientChatReceivedEvent
 import net.minecraftforge.event.entity.EntityJoinWorldEvent
 import net.minecraftforge.fml.common.eventhandler.EventPriority
@@ -24,16 +26,23 @@ object StateManager {
         val unformatted = ev.message.unformattedText
         if (unformatted.matches(Regex(".* a rejoint \\(./2\\)!"))) {
             state = States.GAME
+            if (kira.bot !is Sumo) {
+                LobbyMovement.generic()
+            }
             if (unformatted.matches(Regex(".* a rejoint \\(2/2\\)!"))) {
                 gameFull = true
             }
         } else if (unformatted.contains("Opponent:")) {
             state = States.PLAYING
             gameStartedAt = System.currentTimeMillis()
+            LobbyMovement.stop()
         } else if (unformatted.contains("Melee")) {
             state = States.GAME
             gameFull = false
             lastGameDuration = System.currentTimeMillis() - gameStartedAt
+            if (kira.bot !is Sumo) {
+                LobbyMovement.generic()
+            }
         } else if (unformatted.contains("has quit!")) {
             gameFull = false
         }
@@ -45,6 +54,7 @@ object StateManager {
             state = States.LOBBY
             gameFull = false
             gameStartedAt = -1L
+            LobbyMovement.stop()
         }
     }
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
@@ -23,6 +23,41 @@ object LobbyMovement {
         sumo1()
     }
 
+    fun generic() {
+        if (kira.mc.thePlayer != null) {
+            Movement.startForward()
+            Movement.startSprinting()
+
+            intervals.add(TimeUtils.setInterval(
+                fun () {
+                    if (RandomUtils.randomBool()) {
+                        Movement.singleJump(RandomUtils.randomIntInRange(120, 200))
+                    } else {
+                        if (Movement.jumping()) {
+                            Movement.stopJumping()
+                        } else {
+                            Movement.startJumping()
+                        }
+                    }
+                },
+                RandomUtils.randomIntInRange(400, 800),
+                RandomUtils.randomIntInRange(900, 1800)
+            ))
+
+            intervals.add(TimeUtils.setInterval(
+                fun () {
+                    tickYawChange = if (WorldUtils.airInFront(kira.mc.thePlayer, 4f)) {
+                        RandomUtils.randomDoubleInRange(-13.0, 13.0).toFloat()
+                    } else {
+                        0f
+                    }
+                },
+                0,
+                RandomUtils.randomIntInRange(50, 100)
+            ))
+        }
+    }
+
     fun stop() {
         Movement.clearAll()
         tickYawChange = 0f


### PR DESCRIPTION
## Summary
- Implemented `LobbyMovement.generic` for forward sprinting, random jumps, and cliff avoidance yaw changes
- Integrated lobby movement control into `StateManager`, starting for non-Sumo bots and stopping on game start or world join

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
