### PR TITLE
Add configurable stats overlay

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/Kira.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/Kira.kt
@@ -8,6 +8,7 @@ import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.commands.ConfigCommand
 import best.spaghetcodes.kira.core.Config
 import best.spaghetcodes.kira.core.KeyBindings
+import best.spaghetcodes.kira.gui.StatsOverlay
 import best.spaghetcodes.kira.events.packet.PacketListener
 import com.google.gson.Gson
 import net.minecraft.client.Minecraft
@@ -54,6 +55,7 @@ class kira {
         MinecraftForge.EVENT_BUS.register(Mouse)
         MinecraftForge.EVENT_BUS.register(LobbyMovement)
         MinecraftForge.EVENT_BUS.register(KeyBindings)
+        MinecraftForge.EVENT_BUS.register(StatsOverlay())
 
         // Utilise l’accès typé -> aucun Any ici.
         val idx = config?.currentBot ?: 0

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -88,7 +88,10 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
     // -------- Résultat via résumé & kill (FR/EN) --------
 
     private fun parseWinnerFromSummary(lineRaw: String): Pair<String, String>? {
-        val plain = ChatUtils.removeFormatting(lineRaw).replace(Regex("\\s+"), " ").trim()
+        val plain = ChatUtils.removeFormatting(lineRaw)
+            .replace(Regex("\\[[^\\]]+\\]\\s*"), "")
+            .replace(Regex("\\s+"), " ")
+            .trim()
         val leftWins = Regex("^([A-Za-z0-9_]{2,16})\\s+(?:GAGNANT!?|WINNER!?|GAGNANT|WINNER)\\s+([A-Za-z0-9_]{2,16})$", RegexOption.IGNORE_CASE)
         leftWins.matchEntire(plain)?.let { m ->
             return m.groupValues[1] to m.groupValues[2]
@@ -101,7 +104,10 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
     }
 
     private fun parseKillLine(lineRaw: String): Pair<String, String>? {
-        val plain = ChatUtils.removeFormatting(lineRaw).replace(Regex("\\s+"), " ").trim()
+        val plain = ChatUtils.removeFormatting(lineRaw)
+            .replace(Regex("\\[[^\\]]+\\]\\s*"), "")
+            .replace(Regex("\\s+"), " ")
+            .trim()
         val fr = Regex("^([A-Za-z0-9_]{2,16}) a été tué par ([A-Za-z0-9_]{2,16})\\.?$", RegexOption.IGNORE_CASE)
         fr.matchEntire(plain)?.let { m -> return m.groupValues[2] to m.groupValues[1] }
         val en = Regex("^([A-Za-z0-9_]{2,16}) was killed by ([A-Za-z0-9_]{2,16})\\.?$", RegexOption.IGNORE_CASE)

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -36,6 +36,9 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     @Property(type = PropertyType.SWITCH, name = "Disable Chat Messages", description = "When this is enabled, the bot will not send any chat messages.", category = "General")
     var disableChatMessages = false
 
+    @Property(type = PropertyType.SWITCH, name = "Show Stats Overlay", description = "Display session stats on screen.", category = "General")
+    var showStatsOverlay = true
+
     @Property(type = PropertyType.NUMBER, name = "Throw After X Games", description = "After X games the bot will underperform and throw the game. 0 = disabled.", category = "General", min = 0, max = 1000, increment = 10)
     var throwAfterGames = 0
 

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -310,6 +310,11 @@ class CustomConfigGUI : GuiScreen() {
     private fun drawStatsTab(x: Int, yStart: Int): Int {
         var y = yStart
         drawString(fontRendererObj, "§lSESSION STATISTICS", x, y - scroll, primaryColor); y += 25
+        val cfg = kira.config
+        cfg?.let { config ->
+            toggle("Show Stats Overlay", x, y, { config.showStatsOverlay }, { config.showStatsOverlay = it })
+            y += 24
+        }
 
         val wins = Session.wins
         val losses = Session.losses

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/StatsOverlay.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/StatsOverlay.kt
@@ -1,0 +1,60 @@
+package best.spaghetcodes.kira.gui
+
+import best.spaghetcodes.kira.bot.Session
+import best.spaghetcodes.kira.kira
+import net.minecraft.client.gui.Gui
+import net.minecraftforge.client.event.RenderGameOverlayEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import java.text.DecimalFormat
+
+class StatsOverlay {
+
+    private val df = DecimalFormat("#.##")
+
+    @SubscribeEvent
+    fun onRender(event: RenderGameOverlayEvent.Text) {
+        if (kira.config?.showStatsOverlay == false) return
+
+        val mc = kira.mc
+        val wins = Session.wins
+        val losses = Session.losses
+        val total = wins + losses
+
+        val ratio = if (losses == 0) wins.toFloat() else wins.toFloat() / losses
+        val winrate = if (total == 0) 0f else (wins.toFloat() / total) * 100f
+
+        val elapsed = if (Session.startTime > 0) System.currentTimeMillis() - Session.startTime else 0L
+        val hours = elapsed / 1000.0 / 3600.0
+        val winsPerHour = if (hours > 0) wins / hours else 0.0
+        val minutes = elapsed / 1000 / 60
+
+        val lines = mutableListOf(
+            "Wins: $wins",
+            "Losses: $losses",
+            "W/L: ${df.format(ratio)}",
+            "Winrate: ${df.format(winrate)}%"
+        )
+
+        if (elapsed > 0) {
+            lines += "Wins/h: ${df.format(winsPerHour)}"
+            lines += "Time: ${minutes}m"
+        }
+
+        val fr = mc.fontRendererObj
+        var maxWidth = 0
+        for (s in lines) {
+            maxWidth = maxWidth.coerceAtLeast(fr.getStringWidth(s))
+        }
+
+        val x = 4
+        val y = 4
+        val lineHeight = fr.FONT_HEIGHT + 2
+        val bgColor = 0x55000000.toInt()
+        Gui.drawRect(x - 2, y - 2, x + maxWidth + 2, y + lineHeight * lines.size, bgColor)
+
+        lines.forEachIndexed { index, s ->
+            fr.drawString(s, x, y + index * lineHeight, 0xFFFFFF)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- show session stats overlay with wins, losses, ratio, win rate, wins per hour and runtime
- add config option and GUI toggle for displaying the stats overlay
- register the overlay during mod initialization
- strip rank prefixes before parsing post-game summaries to detect wins/losses in localized chats