### PR TITLE
Cancel bow when target closes distance

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -2,6 +2,7 @@ package best.spaghetcodes.kira.bot.bots
 
 import best.spaghetcodes.kira.bot.BotBase
 import best.spaghetcodes.kira.bot.features.Bow
+import best.spaghetcodes.kira.bot.features.cancelBowTimers
 import best.spaghetcodes.kira.bot.features.MovePriority
 import best.spaghetcodes.kira.bot.features.Rod
 import best.spaghetcodes.kira.bot.player.Combat
@@ -325,10 +326,13 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         if (projectileActive && Mouse.rClickDown) {
             if (projectileKind == KIND_BOW && distance < bowCancelCloseDist) {
                 Mouse.rClickUp()
+                Inventory.setInvItem("sword")
+                cancelBowTimers()
                 bowHardLockUntil = 0L
                 projectileGraceUntil = 0L
                 pendingProjectileUntil = 0L
                 actionLockUntil = 0L
+                Mouse.setUsingProjectile(false)
                 projectileKind = KIND_NONE
             }
         }

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -2,6 +2,7 @@ package best.spaghetcodes.kira.bot.bots
 
 import best.spaghetcodes.kira.bot.BotBase
 import best.spaghetcodes.kira.bot.features.Bow
+import best.spaghetcodes.kira.bot.features.cancelBowTimers
 import best.spaghetcodes.kira.bot.features.MovePriority
 import best.spaghetcodes.kira.bot.features.Rod
 import best.spaghetcodes.kira.bot.player.Combat
@@ -507,10 +508,13 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         // Annuler l’arc si trop proche
         if (projectileActive && Mouse.rClickDown && projectileKind == KIND_BOW && distance < bowCancelCloseDist) {
             Mouse.rClickUp()
+            Inventory.setInvItem("sword")
+            cancelBowTimers()
             bowHardLockUntil = 0L
             projectileGraceUntil = 0L
             pendingProjectileUntil = 0L
             actionLockUntil = 0L
+            Mouse.setUsingProjectile(false)
             projectileKind = KIND_NONE
         }
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Bow.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Bow.kt
@@ -9,6 +9,20 @@ import best.spaghetcodes.kira.kira
 import net.minecraft.client.Minecraft
 import java.util.Timer
 
+// Timers used during bow usage so they can be cancelled if needed
+var bowReleaseTimer: Timer? = null
+var bowFinalTimer: Timer? = null
+var bowPollTimer: Timer? = null
+
+fun cancelBowTimers() {
+    bowReleaseTimer?.cancel()
+    bowFinalTimer?.cancel()
+    bowPollTimer?.cancel()
+    bowReleaseTimer = null
+    bowFinalTimer = null
+    bowPollTimer = null
+}
+
 /**
  * Arc (Hypixel Classic/OP)
  * Deux voies :
@@ -43,16 +57,19 @@ interface Bow {
 
             Mouse.rClickDown()
 
-            val releaseTimer = TimeUtils.setTimeout({
+            bowReleaseTimer = TimeUtils.setTimeout({
                 Mouse.rClickUp()
             }, hold)
 
             var pollTimer: Timer? = null
-            val finalTimer = TimeUtils.setTimeout({
+            bowFinalTimer = TimeUtils.setTimeout({
                 pollTimer?.cancel()
                 Mouse.setUsingProjectile(false)
                 Inventory.setInvItem("sword")
                 afterShot()
+                bowReleaseTimer = null
+                bowFinalTimer = null
+                bowPollTimer = null
             }, hold + RandomUtils.randomIntInRange(90, 150))
 
             pollTimer = TimeUtils.setInterval({
@@ -62,15 +79,19 @@ interface Bow {
                     val dist = EntityUtils.getDistanceNoY(player, opp)
                     if (dist <= 5f) {
                         Mouse.rClickUp()
-                        releaseTimer?.cancel()
-                        finalTimer?.cancel()
-                        pollTimer?.cancel()
+                        bowReleaseTimer?.cancel()
+                        bowFinalTimer?.cancel()
+                        bowPollTimer?.cancel()
                         Mouse.setUsingProjectile(false)
                         Inventory.setInvItem("sword")
                         afterShot()
+                        bowReleaseTimer = null
+                        bowFinalTimer = null
+                        bowPollTimer = null
                     }
                 }
             }, 0, 50)
+            bowPollTimer = pollTimer
         }, preDelay)
     }
 
@@ -90,16 +111,19 @@ interface Bow {
         Inventory.setInvItem("bow")
         Mouse.rClickDown()
 
-        val releaseTimer = TimeUtils.setTimeout({
+        bowReleaseTimer = TimeUtils.setTimeout({
             Mouse.rClickUp()
         }, hold)
 
         var pollTimer: Timer? = null
-        val finalTimer = TimeUtils.setTimeout({
+        bowFinalTimer = TimeUtils.setTimeout({
             pollTimer?.cancel()
             Mouse.setUsingProjectile(false)
             Inventory.setInvItem("sword")
             afterShot()
+            bowReleaseTimer = null
+            bowFinalTimer = null
+            bowPollTimer = null
         }, hold + RandomUtils.randomIntInRange(90, 150))
 
         pollTimer = TimeUtils.setInterval({
@@ -109,14 +133,18 @@ interface Bow {
                 val dist = EntityUtils.getDistanceNoY(player, opp)
                 if (dist <= 5f) {
                     Mouse.rClickUp()
-                    releaseTimer?.cancel()
-                    finalTimer?.cancel()
-                    pollTimer?.cancel()
+                    bowReleaseTimer?.cancel()
+                    bowFinalTimer?.cancel()
+                    bowPollTimer?.cancel()
                     Mouse.setUsingProjectile(false)
                     Inventory.setInvItem("sword")
                     afterShot()
+                    bowReleaseTimer = null
+                    bowFinalTimer = null
+                    bowPollTimer = null
                 }
             }
         }, 0, 50)
+        bowPollTimer = pollTimer
     }
 }


### PR DESCRIPTION
## Summary
- track bow timers and expose `cancelBowTimers` to abort bow actions
- ensure Classic bots re-equip swords and reset projectile state when opponents get close

## Testing
- `./gradlew test` (fails: Unable to tunnel through proxy)


------
https://chatgpt.com/codex/tasks/task_e_68b9e0dcf31483298608af49c4f420cf