### PR TITLE
Check opponent velocity before bow

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -8,6 +8,7 @@ import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
 import best.spaghetcodes.kira.utils.*
+import best.spaghetcodes.kira.utils.Extensions.getVelocity
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
 
@@ -28,6 +29,7 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority, Bow {
     private var tapping = false
     private var lastKitSwitch = 0L
     private val kitSwitchCooldown = 3000L
+    private val stationaryThreshold = 0.03
 
     override fun onGameStart() {
         Mouse.startTracking()
@@ -97,9 +99,14 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority, Bow {
         if ((now - lastKitSwitch) > kitSwitchCooldown) {
             when {
                 distance > 8f -> {
-                    // Essayer arc/proj à longue distance
+                    // Essayer arc/proj à longue distance uniquement si l'adversaire est immobile
                     if (distance > 5f) {
-                        useBow(distance)
+                        val oppSpeed = opp.getVelocity().lengthVector()
+                        if (oppSpeed < stationaryThreshold) {
+                            useBow(distance)
+                        } else {
+                            Inventory.setInvItem("sword")
+                        }
                         lastKitSwitch = now
                     } else {
                         if (!Inventory.setInvItem("rod")) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -11,6 +11,7 @@ import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
 import best.spaghetcodes.kira.utils.*
 import best.spaghetcodes.kira.utils.ChatUtils
+import best.spaghetcodes.kira.utils.Extensions.getVelocity
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
 import kotlin.math.abs
@@ -51,6 +52,7 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
     private val singleJumpMinDist = 2.8f
     private val bowSlowThreshold = 0.06
     private val bowSlowFramesNeeded = 3
+    private val stationaryThreshold = 0.03
 
     // --- Rod : fenêtres & timings ---
     private val rodCloseMin = 2.2f
@@ -163,14 +165,19 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
             if (opp != null && !Mouse.isUsingProjectile()) {
                 val d = EntityUtils.getDistanceNoY(mc.thePlayer, opp)
                 if (d >= openShotMinDist && shotsFired < maxArrows) {
-                    val now = System.currentTimeMillis()
-                    bowHardLockUntil = now + RandomUtils.randomIntInRange(fullDrawMsMin, fullDrawMsMax).toLong()
-                    pendingProjectileUntil = now + 60L
-                    actionLockUntil = now + (fullDrawMsMax + 200)
-                    projectileKind = KIND_BOW
-                    val tunedD = if (d in 9.0f..18.5f) d * 0.92f else d
-                    useBow(tunedD) { shotsFired++ }
-                    projectileGraceUntil = bowHardLockUntil + 120
+                    val oppSpeed = opp.getVelocity().lengthVector()
+                    if (oppSpeed < stationaryThreshold) {
+                        val now = System.currentTimeMillis()
+                        bowHardLockUntil = now + RandomUtils.randomIntInRange(fullDrawMsMin, fullDrawMsMax).toLong()
+                        pendingProjectileUntil = now + 60L
+                        actionLockUntil = now + (fullDrawMsMax + 200)
+                        projectileKind = KIND_BOW
+                        val tunedD = if (d in 9.0f..18.5f) d * 0.92f else d
+                        useBow(tunedD) { shotsFired++ }
+                        projectileGraceUntil = bowHardLockUntil + 120
+                    } else {
+                        Inventory.setInvItem("sword")
+                    }
                 }
             }
         }, RandomUtils.randomIntInRange(350, 650))
@@ -493,14 +500,19 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
             if ((EntityUtils.entityFacingAway(p, opp) && distance in 3.5f..30f) ||
                 (distance in 28.0f..33.0f && !EntityUtils.entityFacingAway(p, opp))) {
                 if (distance > 10f && shotsFired < maxArrows) {
-                    val tunedD = if (distance in 9.0f..18.5f) distance * 0.92f else distance
-                    bowHardLockUntil = now + RandomUtils.randomIntInRange(fullDrawMsMin, fullDrawMsMax).toLong()
-                    pendingProjectileUntil = now + 60L
-                    actionLockUntil = now + (fullDrawMsMax + 100)
-                    projectileKind = KIND_BOW
-                    useBow(tunedD) { shotsFired++ }
-                    projectileGraceUntil = bowHardLockUntil + 120
-                    return
+                    val oppSpeed = opp.getVelocity().lengthVector()
+                    if (oppSpeed < stationaryThreshold) {
+                        val tunedD = if (distance in 9.0f..18.5f) distance * 0.92f else distance
+                        bowHardLockUntil = now + RandomUtils.randomIntInRange(fullDrawMsMin, fullDrawMsMax).toLong()
+                        pendingProjectileUntil = now + 60L
+                        actionLockUntil = now + (fullDrawMsMax + 100)
+                        projectileKind = KIND_BOW
+                        useBow(tunedD) { shotsFired++ }
+                        projectileGraceUntil = bowHardLockUntil + 120
+                        return
+                    } else {
+                        Inventory.setInvItem("sword")
+                    }
                 }
             }
         }

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -10,6 +10,7 @@ import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
 import best.spaghetcodes.kira.utils.*
+import best.spaghetcodes.kira.utils.Extensions.getVelocity
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
 import kotlin.math.abs
@@ -51,6 +52,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
     private val stillFramesNeeded = 10
     private val bowSlowThreshold = 0.06
     private val bowSlowFramesNeeded = 3
+    private val stationaryThreshold = 0.03
     private var oppLastX = 0.0
     private var oppLastZ = 0.0
     private var stillFrames = 0
@@ -736,15 +738,20 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
                     pendingProjectileUntil = now + 60L
                     actionLockUntil = now + (lock + 120)
                     projectileKind = KIND_BOW
-                    useBow(tunedD) {
-                        shotsFired++
-                        openVolleyFired++
-                        lastShotAt = System.currentTimeMillis()
+                    val oppSpeed = opp.getVelocity().lengthVector()
+                    if (oppSpeed < stationaryThreshold) {
+                        useBow(tunedD) {
+                            shotsFired++
+                            openVolleyFired++
+                            lastShotAt = System.currentTimeMillis()
+                        }
+                        projectileGraceUntil = bowHardLockUntil + 120
+                        postBowNoRodUntil = now + lock + 380L
+                        prevDistance = distance
+                        return
+                    } else {
+                        Inventory.setInvItem("sword")
                     }
-                    projectileGraceUntil = bowHardLockUntil + 120
-                    postBowNoRodUntil = now + lock + 380L
-                    prevDistance = distance
-                    return
                 }
             }
 
@@ -768,14 +775,19 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
                     pendingProjectileUntil = now + 50L
                     actionLockUntil = now + (lock + 100)
                     projectileKind = KIND_BOW
-                    useBow(tunedD) {
-                        shotsFired++
-                        lastReactiveShotAt = System.currentTimeMillis()
+                    val oppSpeed = opp.getVelocity().lengthVector()
+                    if (oppSpeed < stationaryThreshold) {
+                        useBow(tunedD) {
+                            shotsFired++
+                            lastReactiveShotAt = System.currentTimeMillis()
+                        }
+                        projectileGraceUntil = bowHardLockUntil + 100
+                        postBowNoRodUntil = now + lock + 320L
+                        prevDistance = distance
+                        return
+                    } else {
+                        Inventory.setInvItem("sword")
                     }
-                    projectileGraceUntil = bowHardLockUntil + 100
-                    postBowNoRodUntil = now + lock + 320L
-                    prevDistance = distance
-                    return
                 }
             }
 
@@ -795,11 +807,16 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
                         pendingProjectileUntil = now + 60L
                         actionLockUntil = now + (lock + 120)
                         projectileKind = KIND_BOW
-                        useBow(tunedD) { shotsFired++ }
-                        projectileGraceUntil = bowHardLockUntil + 120
-                        postBowNoRodUntil = now + lock + 320L
-                        prevDistance = distance
-                        return
+                        val oppSpeed = opp.getVelocity().lengthVector()
+                        if (oppSpeed < stationaryThreshold) {
+                            useBow(tunedD) { shotsFired++ }
+                            projectileGraceUntil = bowHardLockUntil + 120
+                            postBowNoRodUntil = now + lock + 320L
+                            prevDistance = distance
+                            return
+                        } else {
+                            Inventory.setInvItem("sword")
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -8,6 +8,7 @@ import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
 import best.spaghetcodes.kira.utils.*
+import best.spaghetcodes.kira.utils.Extensions.getVelocity
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
 import java.util.Random
@@ -42,6 +43,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
     override var lastGap = 0L
 
     var tapping = false
+    private val stationaryThreshold = 0.03
 
     override fun onGameStart() {
         Mouse.startTracking()                 // tracking ON
@@ -176,8 +178,16 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
                 } else if ((EntityUtils.entityFacingAway(mc.thePlayer, opponent()!!) && distance in 3.5f..30f) ||
                            (distance in 28.0f..33.0f && !EntityUtils.entityFacingAway(mc.thePlayer, opponent()!!))) {
                     if (distance > 10f && shotsFired < maxArrows && System.currentTimeMillis() - lastPotion > 5000) {
-                        clear = true
-                        useBow(distance) { shotsFired++ }
+                        val oppSpeed = opponent()!!.getVelocity().lengthVector()
+                        if (oppSpeed < stationaryThreshold) {
+                            clear = true
+                            useBow(distance) { shotsFired++ }
+                        } else {
+                            clear = false
+                            Inventory.setInvItem("sword")
+                            if (WorldUtils.leftOrRightToPoint(mc.thePlayer, Vec3(0.0, 0.0, 0.0))) movePriority[0] += 4
+                            else movePriority[1] += 4
+                        }
                     } else {
                         clear = false
                         if (WorldUtils.leftOrRightToPoint(mc.thePlayer, Vec3(0.0, 0.0, 0.0))) movePriority[0] += 4


### PR DESCRIPTION
## Summary
- Compute opponent velocity before equipping bows in Blitz, Classic, ClassicV2, and OP bots
- Skip bow usage if foe is moving; fall back to sword

## Testing
- `gradle build` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.7.10'] was not found)*

-----