### PR TITLE
Allow zero CPS values and avoid divide-by-zero in auto-clicker

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -127,6 +127,8 @@ object Mouse {
                 val minCPS = kira.config?.minCPS ?: 10
                 val maxCPS = kira.config?.maxCPS ?: 14
 
+                if (minCPS <= 0 || maxCPS <= 0) return
+
                 if (System.currentTimeMillis() >= lastLeftClick + (1000 / RandomUtils.randomIntInRange(minCPS, maxCPS))) {
                     leftClick()
                     lastLeftClick = System.currentTimeMillis()

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -48,10 +48,10 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     @Property(type = PropertyType.NUMBER, name = "Disconnect After X Minutes", description = "After X minutes the bot will toggle off and disconnect. 0 = disabled", category = "General", min = 0, max = 500, increment = 30)
     var disconnectAfterMinutes = 0
 
-    @Property(type = PropertyType.NUMBER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 1, max = 25, increment = 1)
+    @Property(type = PropertyType.NUMBER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25, increment = 1)
     var minCPS = 15
 
-    @Property(type = PropertyType.NUMBER, name = "Max CPS", description = "The maximum CPS that the bot will be clicking at.", category = "Combat", min = 1, max = 25, increment = 1)
+    @Property(type = PropertyType.NUMBER, name = "Max CPS", description = "The maximum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25, increment = 1)
     var maxCPS = 19
 
     @Property(type = PropertyType.NUMBER, name = "Horizontal Look Speed", description = "Horizontal look speed.", category = "Combat", min = 1, max = 50, increment = 1)

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -293,8 +293,8 @@ class CustomConfigGUI : GuiScreen() {
 
         val cfg = kira.config ?: return y
 
-        number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 15, 25, 1); y += 20
-        number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 19, 25, 1); y += 24
+        number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 0, 25, 1); y += 20
+        number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 0, 25, 1); y += 24
         number("Horizontal Look Speed", x, y, { cfg.lookSpeedHorizontal }, { cfg.lookSpeedHorizontal = it }, 1, 50, 1); y += 20
         number("Vertical Look Speed", x, y, { cfg.lookSpeedVertical }, { cfg.lookSpeedVertical = it }, 1, 50, 1); y += 20
         decimal("Look Randomization", x, y, { cfg.lookRand }, { cfg.lookRand = it }, 0f, 2f, 0.05f); y += 24


### PR DESCRIPTION
## Summary
- Permit 0 CPS values in configuration for minimum and maximum click speed
- Update config GUI to allow CPS values down to 0
- Prevent auto-clicker divide-by-zero when CPS config is set to 0

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
