### PR TITLE
Refine forward movement radius

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -306,7 +306,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         }
 
         // Avance/stop
-        if (distance < 1.5f || (distance < 2.4f && combo >= 1)) {
+        if (distance < 0.8f) {
             Movement.stopForward()
         } else if (!tapping) {
             Movement.startForward()


### PR DESCRIPTION
## Summary
- Tighten forward-stop radius for combo bot to ~0.8 blocks

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
