### PR TITLE
Remove duplicate Min CPS property annotation

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -51,10 +51,7 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     @Property(type = PropertyType.SWITCH, name = "Enable Kira Hits", description = "Whether the bot should perform hits.", category = "Combat")
     var enableHits = true
 
-    @Property(type = PropertyType.NUMBER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 1, max = 25, increment = 1)
-
     @Property(type = PropertyType.NUMBER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25, increment = 1)
-
     var minCPS = 15
 
     @Property(type = PropertyType.NUMBER, name = "Max CPS", description = "The maximum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25, increment = 1)


### PR DESCRIPTION
## Summary
- remove duplicate Min CPS property annotation with `min = 1`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, 403 Forbidden)*
