### PR TITLE
chore: remove unused distance variable in Blitz bot

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -54,7 +54,6 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
     }
 
     override fun onAttack() {
-        val distance = EntityUtils.getDistanceNoY(mc.thePlayer, opponent())
         ChatUtils.info("W-Tap 100")
         Combat.wTap(100)
         tapping = true


### PR DESCRIPTION
## Summary
- remove unused distance calculation in Blitz.onAttack

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*
