### PR TITLE
Remove default value from randomStrafe variable

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/BowDuel.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/BowDuel.kt
@@ -211,7 +211,7 @@ class BowDuel : BotBase("/play duels_bow_duel"), Bow, MovePriority {
         // --------- Strafe / déplacement ----------
         val movePriority = arrayListOf(0, 0)
         var clear = false
-        var randomStrafe = false
+        var randomStrafe: Boolean
 
         // Strafe forcé pendant hop-shot
         if (now < forceStrafeUntil) {


### PR DESCRIPTION
## Summary
- Ensure `randomStrafe` is declared without default initialization in BowDuel logic

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bd84f70d6083298acda1b511644ef9