### PR TITLE
Suppress unused parameter warning in StatsOverlay

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/gui/StatsOverlay.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/StatsOverlay.kt
@@ -12,7 +12,7 @@ class StatsOverlay {
     private val df = DecimalFormat("#.##")
 
     @SubscribeEvent
-    fun onRender(event: RenderGameOverlayEvent.Text) {
+    fun onRender(@Suppress("UNUSED_PARAMETER") event: RenderGameOverlayEvent.Text) {
         if (kira.config?.showStatsOverlay == false) return
 
         val mc = kira.mc


### PR DESCRIPTION
## Summary
- suppress unused parameter warning in `StatsOverlay.onRender`

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
