### PR TITLE
Refine CPS controls in combat config

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -291,12 +291,8 @@ class CustomConfigGUI : GuiScreen() {
         val cfg = kira.config ?: return y
 
         toggle("Enable Kira Hits", x, y, { cfg.enableHits }, { cfg.enableHits = it }); y += 20
-        number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 15, 25, 1); y += 20
-        number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 19, 25, 1); y += 24
-
-
-        number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 0, 25, 1); y += 20
-        number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 0, 25, 1); y += 24
+        number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 1, 25, 1); y += 20
+        number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 1, 25, 1); y += 24
 
         number("Horizontal Look Speed", x, y, { cfg.lookSpeedHorizontal }, { cfg.lookSpeedHorizontal = it }, 1, 50, 1); y += 20
         number("Vertical Look Speed", x, y, { cfg.lookSpeedVertical }, { cfg.lookSpeedVertical = it }, 1, 50, 1); y += 20


### PR DESCRIPTION
## Summary
- Remove duplicate CPS controls from combat tab
- Standardize CPS input limits to 1-25 and realign UI

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

