### PR TITLE
Keep forward movement in combo and allow CPS 0-25

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -306,10 +306,8 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
             Movement.singleJump(RandomUtils.randomIntInRange(100, 150))
         }
 
-        // Avance/stop
-        if (distance < 0.8f) {
-            Movement.stopForward()
-        } else if (!tapping) {
+        // Avance en continu (sauf pendant un wTap)
+        if (!tapping) {
             Movement.startForward()
         }
 

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -51,10 +51,10 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     @Property(type = PropertyType.SWITCH, name = "Enable Kira Hits", description = "Whether the bot should perform hits.", category = "Combat")
     var enableHits = true
 
-    @Property(type = PropertyType.NUMBER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 1, max = 25, increment = 1)
+    @Property(type = PropertyType.NUMBER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25, increment = 1)
     var minCPS = 15
 
-    @Property(type = PropertyType.NUMBER, name = "Max CPS", description = "The maximum CPS that the bot will be clicking at.", category = "Combat", min = 1, max = 25, increment = 1)
+    @Property(type = PropertyType.NUMBER, name = "Max CPS", description = "The maximum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25, increment = 1)
     var maxCPS = 19
 
     @Property(type = PropertyType.NUMBER, name = "Horizontal Look Speed", description = "Horizontal look speed.", category = "Combat", min = 1, max = 50, increment = 1)

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -291,8 +291,8 @@ class CustomConfigGUI : GuiScreen() {
         val cfg = kira.config ?: return y
 
         toggle("Enable Kira Hits", x, y, { cfg.enableHits }, { cfg.enableHits = it }); y += 20
-        number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 1, 25, 1); y += 20
-        number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 1, 25, 1); y += 24
+        number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 0, 25, 1); y += 20
+        number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 0, 25, 1); y += 24
 
         number("Horizontal Look Speed", x, y, { cfg.lookSpeedHorizontal }, { cfg.lookSpeedHorizontal = it }, 1, 50, 1); y += 20
         number("Vertical Look Speed", x, y, { cfg.lookSpeedVertical }, { cfg.lookSpeedVertical = it }, 1, 50, 1); y += 20


### PR DESCRIPTION
## Summary
- Always move forward in Combo mode unless w-tapping
- Allow Min/Max CPS to be set from 0–25 in config and GUI

## Testing
- `gradle build` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.7.10'] was not found)*
