### PR TITLE
Ensure left AC lock reliably resets

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -35,6 +35,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
     // ---- état combat / clic ----
     private var tapping = false
     private var lockLeftAC = false
+    private var lockLeftACSince = 0L
 
     // ---- cycles déterministes (aucun check d'effet) ----
     // Strength : 2 doses, 2e à +294 s après le début de la 1re
@@ -90,15 +91,18 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         val now = System.currentTimeMillis()
         consumingUntil = now + holdMs + 150
         lockLeftAC = true
+        lockLeftACSince = now
         Mouse.stopLeftAC()
         TimeUtils.setTimeout({
             if (returnSword) {
                 Inventory.setInvItem("sword")
                 TimeUtils.setTimeout({
                     lockLeftAC = false
+                    lockLeftACSince = 0L
                 }, RandomUtils.randomIntInRange(120, 200))
             } else {
                 lockLeftAC = false
+                lockLeftACSince = 0L
             }
         }, holdMs + 140)
     }
@@ -241,6 +245,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         closeStrafeToggleAt = 0L
 
         lockLeftAC = false
+        lockLeftACSince = 0L
         tapping = false
     }
 
@@ -251,6 +256,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
             Combat.stopRandomStrafe()
             tapping = false
             lockLeftAC = false
+            lockLeftACSince = 0L
 
             strengthDosesUsed = 0
             lastPotion = 0L
@@ -280,6 +286,18 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
 
         val distance = EntityUtils.getDistanceNoY(player, target)
         val now = System.currentTimeMillis()
+
+        // Fail-safe : unlock left AC if stuck too long
+        if (lockLeftAC && now - lockLeftACSince > 3000) {
+            lockLeftAC = false
+            lockLeftACSince = 0L
+            if (!isConsuming() && !openingPhase && distance < 10) {
+                val held = player.heldItem
+                if (held != null && held.unlocalizedName.lowercase().contains("sword") && kira.config?.enableHits == true) {
+                    Mouse.startLeftAC()
+                }
+            }
+        }
 
         // Toujours sprinter
         if (!player.isSprinting) Movement.startSprinting()
@@ -337,6 +355,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
                 if (player.inventory.armorItemInSlot(i) == null) {
                     Mouse.stopLeftAC()
                     lockLeftAC = true
+                    lockLeftACSince = now
                     if ((armor[i] ?: 0) > 0) {
                         TimeUtils.setTimeout({
                             val a = Inventory.setInvItem(ArmorEnum.values()[i].name.lowercase())
@@ -349,13 +368,22 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
                                         Inventory.setInvItem("sword")
                                         TimeUtils.setTimeout({
                                             lockLeftAC = false
+                                            lockLeftACSince = 0L
                                         }, RandomUtils.randomIntInRange(200, 300))
                                     }, r + RandomUtils.randomIntInRange(100, 150))
                                 }, RandomUtils.randomIntInRange(200, 400))
                             } else {
-                                lockLeftAC = false
+                                TimeUtils.setTimeout({
+                                    lockLeftAC = false
+                                    lockLeftACSince = 0L
+                                }, RandomUtils.randomIntInRange(100, 150))
                             }
                         }, RandomUtils.randomIntInRange(250, 500))
+                    } else {
+                        TimeUtils.setTimeout({
+                            lockLeftAC = false
+                            lockLeftACSince = 0L
+                        }, RandomUtils.randomIntInRange(200, 300))
                     }
                 }
             }
@@ -381,6 +409,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
             lastPearl = now
             Mouse.stopLeftAC()
             lockLeftAC = true
+            lockLeftACSince = now
             TimeUtils.setTimeout({
                 if (Inventory.setInvItem("pearl")) {
                     pearls--
@@ -392,11 +421,15 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
                             Inventory.setInvItem("sword")
                             TimeUtils.setTimeout({
                                 lockLeftAC = false
+                                lockLeftACSince = 0L
                             }, RandomUtils.randomIntInRange(200, 300))
                         }, RandomUtils.randomIntInRange(250, 300))
                     }, RandomUtils.randomIntInRange(300, 600))
                 } else {
-                    lockLeftAC = false
+                    TimeUtils.setTimeout({
+                        lockLeftAC = false
+                        lockLeftACSince = 0L
+                    }, RandomUtils.randomIntInRange(200, 300))
                 }
             }, RandomUtils.randomIntInRange(250, 500))
         }


### PR DESCRIPTION
## Summary
- track when left auto-click lock is activated
- pair all lock branches with timeouts to release lock
- fail-safe unlock after 3s and restart auto-click when possible

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd947523808329a0f7c70b213dfd41