### PR TITLE
Adjust pearl aim based on distance

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -182,6 +182,12 @@ object Mouse {
                 if (_usingPotion) {
                     if (splashAim == 0.0) splashAim = RandomUtils.randomDoubleInRange(80.0, 90.0)
                     rotations[1] = splashAim.toFloat()
+                } else if (
+                    _usingProjectile &&
+                    kira.mc.thePlayer?.heldItem?.unlocalizedName?.lowercase()?.contains("pearl") == true
+                ) {
+                    val dist = EntityUtils.getDistanceNoY(kira.mc.thePlayer, kira.bot?.opponent()!!)
+                    rotations[1] -= dist * 0.8f
                 }
 
                 val lookRand = (kira.config?.lookRand ?: 0).toDouble()


### PR DESCRIPTION
## Summary
- adjust pitch when throwing pearls based on opponent distance

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bda1fc4f548329a378c1408d4f9901