### PR TITLE
Increase Combo pearl cooldown to 11 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Combat:
 ### ⚔️ Gestion intelligente des objets
 - **Épée 🗡️** — *parade automatique* pour bloquer les flèches adverses  
 - **Arc & canne à pêche 🎯** — pression et contrôle de distance  
-- **Enderpearl 🌀** — repositionnement/téléportation tactique  
+- **Enderpearl 🌀** — repositionnement/téléportation tactique (délai de 11 s entre utilisations)
 - **Pomme dorée 🍏** — activation au bon timing pour la régénération
 
 ---

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -376,7 +376,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
             distance > lastOpponentDistance &&
             distance > 6f &&
             pearls > 0 &&
-            now - lastPearl > 5000 &&
+            now - lastPearl > 11000 && // 11s cooldown
             !isConsuming()
         ) {
             lastPearl = now
@@ -491,12 +491,12 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
             }
         }
 
-        // Defensive pearl: break juggle when launched upward
+        // Defensive pearl: break juggle when launched upward (11s cooldown)
         if (!isConsuming() &&
             player.motionY > 0.15 &&
             !player.onGround &&
             pearls > 0 &&
-            now - lastPearl > 5000
+            now - lastPearl > 11000 // 11s cooldown
         ) {
             lastPearl = now
             Mouse.stopLeftAC()
@@ -530,13 +530,13 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
             }, RandomUtils.randomIntInRange(50, 100))
         }
 
-        // Quick pearl (safe hors conso)
+        // Quick pearl (safe hors conso, 11s cooldown)
         if (!isConsuming() &&
             !openingPhase &&
             distance > 18f &&
             EntityUtils.entityFacingAway(target, player) &&
             !Mouse.isRunningAway() &&
-            now - lastPearl > 5000 &&
+            now - lastPearl > 11000 && // 11s cooldown
             pearls > 0
         ) {
             fun pearlRoutine() {


### PR DESCRIPTION
## Summary
- enforce 11s cooldown between enderpearl uses in the Combo bot
- document new 11s delay in code comments and README

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68bda9aa9a508329aab367023fc892b6