### PR TITLE
Clear lingering block on game start/end

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -277,6 +277,8 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         Movement.startForward()
         Mouse.startTracking()
         Mouse.stopLeftAC()
+        Mouse.rClickUp()
+        Inventory.setInvItem("sword")
 
         openingPhase = true
         openingScheduled = false
@@ -308,6 +310,8 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         TimeUtils.setTimeout({
             Movement.clearAll()
             Mouse.stopLeftAC()
+            Mouse.rClickUp()
+            Inventory.setInvItem("sword")
             Combat.stopRandomStrafe()
             tapping = false
             lockLeftAC = false


### PR DESCRIPTION
## Summary
- Release right-click and reselect sword at match start and end to ensure clean state

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bda9a975ac83299c78d67608443739