### PR TITLE
Improve gapple eat confirmation

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -165,6 +165,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
                 gapsBefore += stack.stackSize
             }
         }
+        val hadAbsorption = player.isPotionActive(MCPotion.absorption)
         val ok = equipAndHoldRightClick(
             { equipAny("gap", "gapple", "apple", "golden_apple") },
             { isHoldingGap() },
@@ -179,7 +180,8 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
                         gapsAfter += stack.stackSize
                     }
                 }
-                if (hasAbsorption || gapsAfter < gapsBefore) {
+                val eaten = gapsAfter < gapsBefore && (hadAbsorption || hasAbsorption)
+                if (eaten) {
                     lastGap = System.currentTimeMillis()
                     if (!gapCycleStarted) gapCycleStarted = true
                     nextGapAt = lastGap + gapPeriodMs


### PR DESCRIPTION
## Summary
- Ensure Combo bot verifies golden apple consumption by checking inventory decrease and absorption effect only when absent
- Reattempt gapple eating when confirmation fails to avoid skipping

## Testing
- ⚠️ `./gradlew test` *(failed: Unable to tunnel through proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bde0fa3cb883298fd1f10d8fa2aad0