### PR TITLE
Reduce defensive and quick pearl time guard

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -439,7 +439,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         if (!isConsuming() &&
             player.motionY > 0.15 &&
             !player.onGround &&
-            now - gameStartAt > 240_000L &&
+            now - gameStartAt > 120_000L &&
             pearls > 0 &&
             now - lastPearl > 11000 // 11s cooldown
         ) {
@@ -479,7 +479,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         if (!isConsuming() &&
             !openingPhase &&
             distance > 24f &&
-            now - gameStartAt > 240_000L &&
+            now - gameStartAt > 120_000L &&
             EntityUtils.entityFacingAway(target, player) &&
             !Mouse.isRunningAway() &&
             now - lastPearl > 11000 && // 11s cooldown


### PR DESCRIPTION
## Summary
- halve time guard before defensive and quick pearls from 240s to 120s while keeping 11s cooldown

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.7.10'] was not found; could not resolve plugin artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68bde3228a888329bb9a6c46b01f8220