### PR TITLE
Ensure config is saved consistently

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/Kira.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/Kira.kt
@@ -45,7 +45,10 @@ class kira {
     @Suppress("UNUSED_PARAMETER")
     fun init(event: FMLInitializationEvent) {
         config = Config()
-        config?.preload()
+
+        Runtime.getRuntime().addShutdownHook(Thread {
+            config?.writeData()
+        })
 
         ConfigCommand().register()
         KeyBindings.register()

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -10,7 +10,7 @@ import gg.essential.vigilance.data.PropertyType
 import net.minecraft.client.gui.GuiScreen
 import java.io.File
 
-class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorter()) {
+class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() }, sortingBehavior = ConfigSorter()) {
 
     @Property(
         type = PropertyType.SELECTOR,
@@ -173,6 +173,7 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
             getBot(idx)?.let { kira.swapBot(it) }
         }
 
+        preload()
         initialize()
     }
 

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -54,6 +54,7 @@ class CustomConfigGUI : GuiScreen() {
         super.onGuiClosed()
         Keyboard.enableRepeatEvents(false)
         focus = Tf.NONE
+        saveConfig()
     }
 
     override fun handleMouseInput() {
@@ -381,13 +382,16 @@ class CustomConfigGUI : GuiScreen() {
     }
 
     private fun saveAndClose() {
+        ChatUtils.info("Configuration saved!")
+        mc.displayGuiScreen(null)
+    }
+
+    private fun saveConfig() {
         kira.config?.let {
             it.startMessage = startMsgBuf
             it.ggMessage = ggMsgBuf
             it.writeData()
         }
-        ChatUtils.info("Configuration saved!")
-        mc.displayGuiScreen(null)
     }
 
     override fun doesGuiPauseGame(): Boolean = false


### PR DESCRIPTION
## Summary
- Create config directory before loading and preload saved settings on init
- Persist config on GUI close and JVM shutdown

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bde3a8413083298627670318742c9e