### PR TITLE
Handle missing entities before starting Combo opening

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -249,9 +249,14 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         openingScheduled = true
 
         TimeUtils.setTimeout({
-            val player = mc.thePlayer ?: return@setTimeout
-            val target = opponent() ?: return@setTimeout
+            val player = mc.thePlayer
+            val target = opponent()
+            if (player == null || target == null) {
+                openingScheduled = false
+                return@setTimeout
+            }
             startOpening(player, target)
+            openingScheduled = true
         }, 0)
 
         strengthDosesUsed = 0


### PR DESCRIPTION
## Summary
- safely reschedule opening sequence when player or target is missing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bde759b9088329956ea9f73dd3a62d