### PR TITLE
Gate lobby movement with config toggle

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
@@ -26,7 +26,7 @@ object StateManager {
         val unformatted = ev.message.unformattedText
         if (unformatted.matches(Regex(".* a rejoint \\(./2\\)!"))) {
             state = States.GAME
-            if (kira.bot !is Sumo) {
+            if (kira.bot !is Sumo && kira.config?.lobbyMovement == true) {
                 LobbyMovement.generic()
             }
             if (unformatted.matches(Regex(".* a rejoint \\(2/2\\)!"))) {
@@ -40,7 +40,7 @@ object StateManager {
             state = States.GAME
             gameFull = false
             lastGameDuration = System.currentTimeMillis() - gameStartedAt
-            if (kira.bot !is Sumo) {
+            if (kira.bot !is Sumo && kira.config?.lobbyMovement == true) {
                 LobbyMovement.generic()
             }
         } else if (unformatted.contains("has quit!")) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
@@ -111,7 +111,9 @@ object LobbyMovement {
     @SubscribeEvent
     @Suppress("UNUSED_PARAMETER")
     fun onTick(event: ClientTickEvent) {
-        if (kira.bot?.toggled() == true && tickYawChange != 0f && kira.mc.thePlayer != null && StateManager.state != StateManager.States.PLAYING) {
+        if (kira.bot?.toggled() == true && kira.config?.lobbyMovement == true && tickYawChange != 0f &&
+            kira.mc.thePlayer != null && StateManager.state != StateManager.States.PLAYING
+        ) {
             kira.mc.thePlayer.rotationYaw += tickYawChange
         }
     }

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -4,6 +4,7 @@ import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.bot.BotBase
 import best.spaghetcodes.kira.bot.bots.*
 import best.spaghetcodes.kira.gui.CustomConfigGUI
+import best.spaghetcodes.kira.bot.player.LobbyMovement
 import gg.essential.vigilance.Vigilant
 import gg.essential.vigilance.data.Property
 import gg.essential.vigilance.data.PropertyType
@@ -171,6 +172,9 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
         // Toujours utiliser getBot ici -> pas d'Any
         registerListener("currentBot") { idx: Int ->
             getBot(idx)?.let { kira.swapBot(it) }
+        }
+        registerListener("lobbyMovement") { enabled: Boolean ->
+            if (!enabled) LobbyMovement.stop()
         }
 
         preload()


### PR DESCRIPTION
## Summary
- Gate LobbyMovement.generic calls behind lobbyMovement config
- Only adjust rotation on tick when lobby movement enabled
- Stop lobby movement when config toggled off

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a39058483298955c9c6f7a5fddf