### PR TITLE
Add obstacle detection for lobby movement with randomized turning

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
@@ -13,6 +13,7 @@ object LobbyMovement {
 
     private var tickYawChange = 0f
     private var initialYaw = 0f
+    private var lastDirectionChange = 0L
     private var intervals: ArrayList<Timer?> = ArrayList()
 
     fun sumo() {
@@ -29,6 +30,7 @@ object LobbyMovement {
             Movement.startForward()
             Movement.startSprinting()
             initialYaw = kira.mc.thePlayer.rotationYaw
+            lastDirectionChange = System.currentTimeMillis()
 
             intervals.add(TimeUtils.setInterval(
                 fun () {
@@ -48,7 +50,9 @@ object LobbyMovement {
 
             intervals.add(TimeUtils.setInterval(
                 fun () {
-                    tickYawChange = if (WorldUtils.airInFront(kira.mc.thePlayer, 4f)) {
+                    val now = System.currentTimeMillis()
+                    tickYawChange = if (WorldUtils.isObstacleAhead(kira.mc.thePlayer, 4f) || now - lastDirectionChange > 7000) {
+                        lastDirectionChange = now
                         RandomUtils.randomDoubleInRange(-13.0, 13.0).toFloat()
                     } else {
                         0f
@@ -68,11 +72,10 @@ object LobbyMovement {
 
     private fun sumo1() {
         if (kira.mc.thePlayer != null) {
-            var left = RandomUtils.randomBool()
-
             val speed = RandomUtils.randomDoubleInRange(3.0, 9.0).toFloat()
-
-            tickYawChange = if (left) -speed else speed
+            val dir = if (RandomUtils.randomBool()) -1 else 1
+            tickYawChange = speed * dir
+            lastDirectionChange = System.currentTimeMillis()
             TimeUtils.setTimeout(fun () {
                 Movement.startForward()
                 Movement.startSprinting()
@@ -80,19 +83,20 @@ object LobbyMovement {
                     Movement.startJumping()
                 }, RandomUtils.randomIntInRange(400, 800))
                 intervals.add(TimeUtils.setInterval(fun () {
-                    tickYawChange = if (WorldUtils.airInFront(kira.mc.thePlayer, 7f)) {
-                        if (WorldUtils.airInFront(kira.mc.thePlayer, 3f)) {
-                            RandomUtils.randomDoubleInRange(if (left) 9.5 else -9.5, if (left) 13.0 else -13.0).toFloat()
-                        } else RandomUtils.randomDoubleInRange(if (left) 4.5 else -4.5, if (left) 7.0 else -7.0).toFloat()
+                    val now = System.currentTimeMillis()
+                    val needTurn = WorldUtils.isObstacleAhead(kira.mc.thePlayer, 7f) || now - lastDirectionChange > 7000
+                    tickYawChange = if (needTurn) {
+                        lastDirectionChange = now
+                        val turnDir = if (RandomUtils.randomBool()) 1 else -1
+                        if (WorldUtils.isObstacleAhead(kira.mc.thePlayer, 3f)) {
+                            RandomUtils.randomDoubleInRange(9.5, 13.0).toFloat() * turnDir
+                        } else {
+                            RandomUtils.randomDoubleInRange(4.5, 7.0).toFloat() * turnDir
+                        }
                     } else {
                         0f
                     }
                 }, 0, RandomUtils.randomIntInRange(50, 100)))
-                intervals.add(TimeUtils.setTimeout(fun () {
-                    intervals.add(TimeUtils.setInterval(fun () {
-                        left = !left
-                    }, 0, RandomUtils.randomIntInRange(5000, 10000)))
-                }, RandomUtils.randomIntInRange(5000, 10000)))
             }, RandomUtils.randomIntInRange(100, 250))
         }
     }

--- a/src/main/kotlin/best/spaghetcodes/kira/utils/WorldUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/WorldUtils.kt
@@ -25,6 +25,23 @@ object WorldUtils {
         return kira.mc.theWorld.getBlockState(player.position.add(vec.xCoord, -0.2 + yMod, vec.zCoord)).block
     }
 
+    /**
+     * Checks for solid blocks at the player's eye height within [distance] blocks ahead
+     */
+    fun isObstacleAhead(player: EntityPlayer, distance: Float): Boolean {
+        val eyePos = player.position.add(0.0, player.eyeHeight.toDouble(), 0.0)
+        val lookVec = EntityUtils.get2dLookVec(player)
+        for (i in 1..distance.toInt()) {
+            val block = kira.mc.theWorld.getBlockState(
+                BlockPos(eyePos.x + lookVec.xCoord * i, eyePos.y, eyePos.z + lookVec.zCoord * i)
+            ).block
+            if (block != Blocks.air) {
+                return true
+            }
+        }
+        return false
+    }
+
     fun airInFront(player: EntityPlayer, distance: Float): Boolean {
         return airCheck(player, player.position, distance, EntityUtils.get2dLookVec(player))
     }


### PR DESCRIPTION
## Summary
- add eye-level obstacle detection helper
- use obstacle detection in generic and sumo lobby movement and randomize turning, with a 7s straight run cap

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be6ad8f2ec8329933f20b2367c0f55