### PR TITLE
Ensure consistent numeric types in BlockPos constructor

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/utils/WorldUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/WorldUtils.kt
@@ -33,7 +33,7 @@ object WorldUtils {
         val lookVec = EntityUtils.get2dLookVec(player)
         for (i in 1..distance.toInt()) {
             val block = kira.mc.theWorld.getBlockState(
-                BlockPos(eyePos.x + lookVec.xCoord * i, eyePos.y, eyePos.z + lookVec.zCoord * i)
+                BlockPos(eyePos.x + lookVec.xCoord * i, eyePos.y.toDouble(), eyePos.z + lookVec.zCoord * i)
             ).block
             if (block != Blocks.air) {
                 return true


### PR DESCRIPTION
## Summary
- use consistent numeric types when creating BlockPos in `WorldUtils.isObstacleAhead`

## Testing
- `./gradlew build` (fails: Unable to tunnel through proxy HTTP/1.1 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68be6e436d04832988031e998e0fb7bc