### PR TITLE
Use consistent numeric types in BlockPos lookup

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/utils/WorldUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/WorldUtils.kt
@@ -33,7 +33,11 @@ object WorldUtils {
         val lookVec = EntityUtils.get2dLookVec(player)
         for (i in 1..distance.toInt()) {
             val block = kira.mc.theWorld.getBlockState(
-                BlockPos(eyePos.x + lookVec.xCoord * i, eyePos.y.toDouble(), eyePos.z + lookVec.zCoord * i)
+                BlockPos(
+                    eyePos.x.toDouble() + lookVec.xCoord * i,
+                    eyePos.y.toDouble(),
+                    eyePos.z.toDouble() + lookVec.zCoord * i
+                )
             ).block
             if (block != Blocks.air) {
                 return true


### PR DESCRIPTION
## Summary
- Refactor BlockPos construction in isObstacleAhead to explicitly convert all coordinates to doubles

## Testing
- ⚠️ `./gradlew build` (failed: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")

------
https://chatgpt.com/codex/tasks/task_e_68be6fa3ab6c83299ce5efb540dd786b