### PR TITLE
Enable distance-based rod logic without initial bow shot

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -610,7 +610,6 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         }
 
         // =======================  ROD  ===========================
-        if (shotsFired == 0 && distance > 5f) return
         // Priorité : adversaire immobile à MID (5–7) => spam rod contrôlé
         val oppHasBow = opp.heldItem != null && opp.heldItem.unlocalizedName.lowercase().contains("bow")
         val bowLikelyNowClose = oppHasBow && (isStillNow || bowSlowFrames >= bowSlowFramesNeeded) && distance <= 10.0f


### PR DESCRIPTION
## Summary
- Remove early return that skipped rod logic before the first bow shot
- Rod usage now solely determined by distance thresholds (`rodCloseMin`, `rodMainMax`, etc.)

## Testing
- `gradle test` *(fails: Plugin org.jetbrains.kotlin.jvm:1.7.10 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb947f2b48329a38d721c784b3e1a