### PR TITLE
fix: cast attack distance to float

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -439,7 +439,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         val now = System.currentTimeMillis()
         val distance = EntityUtils.getDistanceNoY(p, opp)
-        val attackDist = kira.config?.maxDistanceAttack ?: 5f
+        val attackDist = kira.config?.maxDistanceAttack?.toFloat() ?: 5f
         if (distance <= attackDist && !Mouse.isUsingProjectile()) {
             Mouse.startLeftAC()
         } else {


### PR DESCRIPTION
## Summary
- cast `maxDistanceAttack` to float in `ClassicV2` bot

## Testing
- `gradle build --offline` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.7.10'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc363d45483298712b6e1cfb6386d