### PR TITLE
Delay right click after left attack

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -77,7 +77,8 @@ object Mouse {
                     hitsUntilBlock--
                     if (hitsUntilBlock <= 0) {
                         if (RandomUtils.randomIntInRange(0, 100) < (kira.config?.hitAndBlockPercent ?: 100)) {
-                            rClick(RandomUtils.randomIntInRange(60, 120))
+                            val duration = RandomUtils.randomIntInRange(60, 120)
+                            TimeUtils.setTimeout({ rClick(duration) }, 40)
                         }
                         resetHitsUntilBlock()
                     }


### PR DESCRIPTION
## Summary
- delay block right-click by 40 ms after attacking

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68bfdeb9826c83298d1be94e90c1f072