### PR TITLE
Refactor block hit configuration

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -31,9 +31,8 @@ object Mouse {
     private var splashAim = 0.0
 
     private fun resetHitsUntilBlock() {
-        val minHits = kira.config?.hitAndBlockMinHits ?: 1
-        val maxHits = kira.config?.hitAndBlockMaxHits ?: 1
-        hitsUntilBlock = RandomUtils.randomIntInRange(minHits, maxHits)
+        val interval = kira.config?.blockHitInterval ?: 1
+        hitsUntilBlock = interval
     }
 
     // ---- Bow ballistic compensation (pitch) ----
@@ -91,14 +90,14 @@ object Mouse {
             kira.mc.thePlayer != null &&
             !kira.mc.thePlayer.isUsingItem
         ) {
-            val doHitAndBlock = kira.config?.hitAndBlock == true && kira.config?.enableHits == true
+            val doHitAndBlock = kira.config?.blockHit == true && kira.config?.enableHits == true
             if (doHitAndBlock) {
                 if (hitsUntilBlock <= 0) {
                     resetHitsUntilBlock()
                 }
                 hitsUntilBlock--
                 if (hitsUntilBlock <= 0) {
-                    if (RandomUtils.randomIntInRange(0, 100) < (kira.config?.hitAndBlockPercent ?: 100)) {
+                    if (RandomUtils.randomIntInRange(0, 100) < (kira.config?.blockHitPercent ?: 100)) {
                         val duration = RandomUtils.randomIntInRange(60, 120)
                         val target = kira.mc.objectMouseOver?.entityHit
                         if (!rClickDown) {

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -52,17 +52,14 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
     @Property(type = PropertyType.SWITCH, name = "Enable Kira Hits", description = "Whether the bot should perform hits.", category = "Combat")
     var enableHits = true
 
-    @Property(type = PropertyType.SWITCH, name = "Hit and Block", description = "Block after hitting an opponent.", category = "Combat")
-    var hitAndBlock = false
+    @Property(type = PropertyType.SWITCH, name = "Block Hit", description = "Block after hitting an opponent.", category = "Combat")
+    var blockHit = false
 
-    @Property(type = PropertyType.SLIDER, name = "Hit and Block Percent", description = "Chance of blocking after hitting.", category = "Combat", min = 0, max = 100, increment = 5)
-    var hitAndBlockPercent = 50
+    @Property(type = PropertyType.SLIDER, name = "Block Hit Percent", description = "Chance of blocking after hitting.", category = "Combat", min = 0, max = 100, increment = 5)
+    var blockHitPercent = 50
 
-    @Property(type = PropertyType.NUMBER, name = "Hit and Block Min Hits", description = "Minimum hits before blocking.", category = "Combat", min = 1, max = 20, increment = 1)
-    var hitAndBlockMinHits = 2
-
-    @Property(type = PropertyType.NUMBER, name = "Hit and Block Max Hits", description = "Maximum hits before blocking.", category = "Combat", min = 1, max = 20, increment = 1)
-    var hitAndBlockMaxHits = 5
+    @Property(type = PropertyType.NUMBER, name = "Block Hit Interval", description = "Hits before blocking.", category = "Combat", min = 1, max = 20, increment = 1)
+    var blockHitInterval = 3
 
     @Property(type = PropertyType.SLIDER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25)
     var minCPS = 15
@@ -180,10 +177,9 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
         addDependency("dodgeWLR", "enableDodging")
         addDependency("dodgeLostTo", "enableDodging")
         addDependency("dodgeNoStats", "enableDodging")
-        addDependency("hitAndBlock", "enableHits")
-        addDependency("hitAndBlockPercent", "hitAndBlock")
-        addDependency("hitAndBlockMinHits", "hitAndBlock")
-        addDependency("hitAndBlockMaxHits", "hitAndBlock")
+        addDependency("blockHit", "enableHits")
+        addDependency("blockHitPercent", "blockHit")
+        addDependency("blockHitInterval", "blockHit")
 
         // Toujours utiliser getBot ici -> pas d'Any
         registerListener("currentBot") { idx: Int ->

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -292,10 +292,9 @@ class CustomConfigGUI : GuiScreen() {
         val cfg = kira.config ?: return y
 
         toggle("Enable Kira Hits", x, y, { cfg.enableHits }, { cfg.enableHits = it }); y += 20
-        toggle("Hit & Block", x, y, { cfg.hitAndBlock }, { cfg.hitAndBlock = it }); y += 20
-        number("Hit & Block %", x, y, { cfg.hitAndBlockPercent }, { cfg.hitAndBlockPercent = it }, 0, 100, 5); y += 20
-        number("Min Hits Until Block", x, y, { cfg.hitAndBlockMinHits }, { cfg.hitAndBlockMinHits = it }, 1, 20, 1); y += 20
-        number("Max Hits Until Block", x, y, { cfg.hitAndBlockMaxHits }, { cfg.hitAndBlockMaxHits = it }, 1, 20, 1); y += 24
+        toggle("Block Hit", x, y, { cfg.blockHit }, { cfg.blockHit = it }); y += 20
+        number("Block Hit %", x, y, { cfg.blockHitPercent }, { cfg.blockHitPercent = it }, 0, 100, 5); y += 20
+        number("Block Hit Interval", x, y, { cfg.blockHitInterval }, { cfg.blockHitInterval = it }, 1, 20, 1); y += 24
         number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 0, 25, 1); y += 20
         number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 0, 25, 1); y += 24
 


### PR DESCRIPTION
## Summary
- Rename hit and block settings to Block Hit
- Consolidate hit window into blockHitInterval and update GUI
- Adjust mouse logic to respect new configuration

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c00552dcdc8329b8cec2fee346c313