### PR TITLE
Trigger block hit after attacks and add tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
 
     compileOnly("org.spongepowered:mixin:0.8.5-SNAPSHOT")
     annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT:processor")
+
+    testImplementation(kotlin("test"))
+    testImplementation("io.mockk:mockk:1.13.5")
 }
 
 repositories {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -59,6 +59,7 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
         tapping = true
         TimeUtils.setTimeout({ tapping = false }, 100)
         if (combo >= 3) Movement.clearLeftRight()
+        Mouse.leftClick()
     }
 
     override fun onTick() {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/BowDuel.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/BowDuel.kt
@@ -90,6 +90,10 @@ class BowDuel : BotBase("/play duels_bow_duel"), Bow, MovePriority {
         }, RandomUtils.randomIntInRange(200, 400))
     }
 
+    override fun onAttack() {
+        Mouse.leftClick()
+    }
+
     override fun onTick() {
         val p = mc.thePlayer ?: return
         val opp = opponent() ?: return

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
@@ -66,6 +66,7 @@ class Boxing : BotBase("/play duels_boxing_duel"), MovePriority {
         Combat.wTap(100)
         TimeUtils.setTimeout(fun () { tapping = false }, 100)
         if (combo >= 3) Movement.clearLeftRight()
+        Mouse.leftClick()
     }
 
     override fun onTick() {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -92,6 +92,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
                 }
             }
         }
+        Mouse.leftClick()
     }
 
     override fun onTick() {

--- a/src/test/kotlin/best/spaghetcodes/kira/bot/bots/BlockHitTest.kt
+++ b/src/test/kotlin/best/spaghetcodes/kira/bot/bots/BlockHitTest.kt
@@ -1,0 +1,82 @@
+package best.spaghetcodes.kira.bot.bots
+
+import best.spaghetcodes.kira.bot.BotBase
+import best.spaghetcodes.kira.bot.player.Combat
+import best.spaghetcodes.kira.bot.player.Mouse
+import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.utils.ChatUtils
+import best.spaghetcodes.kira.utils.EntityUtils
+import best.spaghetcodes.kira.utils.TimeUtils
+import io.mockk.*
+import net.minecraft.client.Minecraft
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.item.ItemStack
+import kotlin.test.*
+
+class BlockHitTest {
+
+    @BeforeTest
+    fun setup() {
+        mockkStatic(Minecraft::class)
+        val mc = mockk<Minecraft>(relaxed = true)
+        every { Minecraft.getMinecraft() } returns mc
+
+        mockkObject(ChatUtils)
+        every { ChatUtils.info(any()) } just Runs
+
+        mockkObject(Combat)
+        every { Combat.wTap(any()) } just Runs
+
+        mockkObject(Movement)
+        every { Movement.clearLeftRight() } just Runs
+
+        mockkObject(TimeUtils)
+        every { TimeUtils.setTimeout(any(), any()) } returns null
+
+        mockkObject(Mouse)
+        every { Mouse.leftClick() } just Runs
+        every { Mouse.rClick(any()) } just Runs
+
+        mockkObject(EntityUtils)
+        every { EntityUtils.getDistanceNoY(any(), any()) } returns 1f
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun blitzOnAttackTriggersLeftClick() {
+        val bot = Blitz()
+        bot.onAttack()
+        verify(exactly = 1) { Mouse.leftClick() }
+    }
+
+    @Test
+    fun boxingOnAttackTriggersLeftClick() {
+        val bot = Boxing()
+        bot.onAttack()
+        verify(exactly = 1) { Mouse.leftClick() }
+    }
+
+    @Test
+    fun opOnAttackTriggersLeftClick() {
+        val bot = OP()
+
+        val player = mockk<EntityPlayer>(relaxed = true)
+        val sword = mockk<ItemStack>(relaxed = true)
+        every { sword.unlocalizedName } returns "sword"
+        every { player.heldItem } returns sword
+        val mc = Minecraft.getMinecraft()
+        every { mc.thePlayer } returns player
+
+        val opp = mockk<EntityPlayer>(relaxed = true)
+        val field = BotBase::class.java.getDeclaredField("opponent")
+        field.isAccessible = true
+        field.set(bot, opp)
+
+        bot.onAttack()
+        verify(exactly = 1) { Mouse.leftClick() }
+    }
+}


### PR DESCRIPTION
## Summary
- trigger a left click after attacks in non-Combo bots so Block Hit can activate
- cover Blitz, Boxing, and OP bots with tests asserting Block Hit outside Combo mode
- add MockK and kotlin-test to support the new tests

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c0141d00288329b6c78d1c3cabe20d