### PR TITLE
Use explicit kotlin-test-junit artifact for tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,8 +45,7 @@ dependencies {
     compileOnly("org.spongepowered:mixin:0.8.5-SNAPSHOT")
     annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT:processor")
 
-    testImplementation(kotlin("test"))
-    testImplementation(kotlin("test-junit"))
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.7.10")
     testImplementation("io.mockk:mockk:1.13.5")
 }
 

--- a/src/test/kotlin/best/spaghetcodes/kira/bot/bots/BlockHitTest.kt
+++ b/src/test/kotlin/best/spaghetcodes/kira/bot/bots/BlockHitTest.kt
@@ -13,6 +13,12 @@ import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 import kotlin.test.*
 
+private fun invokeOnAttack(bot: BotBase) {
+    val method = BotBase::class.java.getDeclaredMethod("onAttack")
+    method.isAccessible = true
+    method.invoke(bot)
+}
+
 class BlockHitTest {
 
     @BeforeTest
@@ -49,14 +55,14 @@ class BlockHitTest {
     @Test
     fun blitzOnAttackTriggersLeftClick() {
         val bot = Blitz()
-        bot.onAttack()
+        invokeOnAttack(bot)
         verify(exactly = 1) { Mouse.leftClick() }
     }
 
     @Test
     fun boxingOnAttackTriggersLeftClick() {
         val bot = Boxing()
-        bot.onAttack()
+        invokeOnAttack(bot)
         verify(exactly = 1) { Mouse.leftClick() }
     }
 
@@ -76,7 +82,7 @@ class BlockHitTest {
         field.isAccessible = true
         field.set(bot, opp)
 
-        bot.onAttack()
+        invokeOnAttack(bot)
         verify(exactly = 1) { Mouse.leftClick() }
     }
 }


### PR DESCRIPTION
## Summary
- replace Kotlin test dependencies with explicit `kotlin-test-junit:1.7.10`
- invoke protected `onAttack` in tests via reflection to allow compilation

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c029de3bb4832983d1358d8ec8892f