### PR TITLE
Use MockK 1.12.5 in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT:processor")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.7.10")
-    testImplementation("io.mockk:mockk:1.13.5")
+    testImplementation("io.mockk:mockk:1.12.5")
 }
 
 repositories {


### PR DESCRIPTION
## Summary
- Use MockK 1.12.5 for test mocking

## Testing
- `./gradlew clean build --refresh-dependencies` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c02f3397048329b57edadd01b0de3a