### PR TITLE
Enable sword attacks in multiple bots

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -67,7 +67,7 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.stopLeftAC()
+        Mouse.startLeftAC()
 
         val distance = EntityUtils.getDistanceNoY(p, opp)
         val now = System.currentTimeMillis()

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -6,6 +6,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -67,7 +68,7 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.startLeftAC()
+        if (kira.config?.enableHits == true) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
         val distance = EntityUtils.getDistanceNoY(p, opp)
         val now = System.currentTimeMillis()

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
@@ -80,7 +80,7 @@ class Boxing : BotBase("/play duels_boxing_duel"), MovePriority {
             // tracking ON en continu
             Mouse.startTracking()
 
-            Mouse.stopLeftAC()
+            Mouse.startLeftAC()
 
             if (combo >= 3 && distance >= 3.2f && mc.thePlayer.onGround) {
                 Movement.singleJump(RandomUtils.randomIntInRange(100, 150))

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
@@ -80,7 +80,7 @@ class Boxing : BotBase("/play duels_boxing_duel"), MovePriority {
             // tracking ON en continu
             Mouse.startTracking()
 
-            Mouse.startLeftAC()
+            if (kira.config?.enableHits == true) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
             if (combo >= 3 && distance >= 3.2f && mc.thePlayer.onGround) {
                 Movement.singleJump(RandomUtils.randomIntInRange(100, 150))

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -280,7 +280,7 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.stopLeftAC()
+        Mouse.startLeftAC()
 
         val now = System.currentTimeMillis()
         val distance = EntityUtils.getDistanceNoY(p, opp)

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -8,6 +8,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import best.spaghetcodes.kira.utils.ChatUtils
 import net.minecraft.init.Blocks
@@ -280,7 +281,7 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.startLeftAC()
+        if (kira.config?.enableHits == true) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
         val now = System.currentTimeMillis()
         val distance = EntityUtils.getDistanceNoY(p, opp)

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -8,6 +8,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -424,7 +425,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.startLeftAC()
+        if (kira.config?.enableHits == true) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
         // Sauts de début : ACTIFS EN CONTINU jusqu'au PREMIER brandissage d'ARC
         if (startupJumping) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -424,7 +424,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.stopLeftAC()
+        Mouse.startLeftAC()
 
         // Sauts de début : ACTIFS EN CONTINU jusqu'au PREMIER brandissage d'ARC
         if (startupJumping) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -7,6 +7,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -109,7 +110,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             Mouse.startTracking()
 
             // auto-CPS ON
-            Mouse.startLeftAC()
+            if (kira.config?.enableHits == true) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
             if (distance > 8.8f) {
                 if (opponent() != null && opponent()!!.heldItem != null && opponent()!!.heldItem.unlocalizedName.lowercase().contains("bow")) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -108,8 +108,8 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             // tracking ON en continu
             Mouse.startTracking()
 
-            // auto-CPS OFF
-            Mouse.stopLeftAC()
+            // auto-CPS ON
+            Mouse.startLeftAC()
 
             if (distance > 8.8f) {
                 if (opponent() != null && opponent()!!.heldItem != null && opponent()!!.heldItem.unlocalizedName.lowercase().contains("bow")) {


### PR DESCRIPTION
## Summary
- ensure Blitz, Boxing, Classic, ClassicV2 and OP bots initiate left-click attacks while tracking opponents

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy (HTTP/1.1 403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68c03b0c65908329bf67befa8f353b0f