### PR TITLE
Respect enableHits config for Kira hitting

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -8,6 +8,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -310,7 +311,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
     // Série de swings “humains” (2–4 coups) — une seule fois
     private fun triggerHumanSwingSeries() {
-        if (humanSwingSeriesDone) return
+        if (humanSwingSeriesDone || kira.config?.enableHits != true) return
         humanSwingSeriesDone = true
         val swings = RandomUtils.randomIntInRange(2, 4)
         var delay = 0
@@ -449,7 +450,13 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         // Swings humains une seule fois (14–20)
         val inHumanZone = distance in humanSwingZoneMin..humanSwingZoneMax
-        if (!humanSwingSeriesDone && inHumanZone && !wasInHumanZone && now >= humanSwingSeriesActiveUntil) {
+        if (
+            !humanSwingSeriesDone &&
+            inHumanZone &&
+            !wasInHumanZone &&
+            now >= humanSwingSeriesActiveUntil &&
+            kira.config?.enableHits == true
+        ) {
             triggerHumanSwingSeries()
         }
         wasInHumanZone = inHumanZone

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -57,7 +57,12 @@ object Mouse {
     // --------------------------------------------
 
     fun leftClick() {
-        if (kira.bot?.toggled() == true && kira.mc.thePlayer != null && !kira.mc.thePlayer.isUsingItem) {
+        if (
+            kira.bot?.toggled() == true &&
+            kira.config?.enableHits == true &&
+            kira.mc.thePlayer != null &&
+            !kira.mc.thePlayer.isUsingItem
+        ) {
             kira.mc.thePlayer.swingItem()
             KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindAttack.keyCode, true)
             if (kira.mc.objectMouseOver != null && kira.mc.objectMouseOver.entityHit != null) {
@@ -126,7 +131,7 @@ object Mouse {
     }
 
     private fun leftACFunc() {
-        if (kira.bot?.toggled() == true && leftAC) {
+        if (kira.bot?.toggled() == true && kira.config?.enableHits == true && leftAC) {
             if (!kira.mc.thePlayer.isUsingItem) {
                 val minCPS = kira.config?.minCPS ?: 10
                 val maxCPS = kira.config?.maxCPS ?: 14


### PR DESCRIPTION
## Summary
- ensure manual left-clicks only happen when Kira Hits is enabled
- gate autoclicker loop on the Enable Kira Hits setting
- avoid human swing series when hits are disabled

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c0673aaeb48329893c958102048831