### PR TITLE
Enable autoclicker in melee bots

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -67,9 +67,18 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.stopLeftAC()
 
         val distance = EntityUtils.getDistanceNoY(p, opp)
+        val held = p.heldItem
+        val holdingWeapon = held != null && (held.unlocalizedName.lowercase().contains("sword") || held.unlocalizedName.lowercase().contains("axe"))
+        val shouldAttack = !Mouse.isUsingProjectile() && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
+                holdingWeapon && distance <= 3.5f
+        if (shouldAttack) {
+            Mouse.startLeftAC()
+        } else {
+            Mouse.stopLeftAC()
+        }
+
         val now = System.currentTimeMillis()
 
         // Sauts (Blitz un peu plus agressif)

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
@@ -80,7 +80,15 @@ class Boxing : BotBase("/play duels_boxing_duel"), MovePriority {
             // tracking ON en continu
             Mouse.startTracking()
 
-            Mouse.stopLeftAC()
+            val held = mc.thePlayer.heldItem
+            val holdingWeapon = held != null && !held.unlocalizedName.lowercase().contains("bow") && !held.unlocalizedName.lowercase().contains("rod")
+            val shouldAttack = !Mouse.isUsingProjectile() && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
+                    holdingWeapon && distance <= 3.5f
+            if (shouldAttack) {
+                Mouse.startLeftAC()
+            } else {
+                Mouse.stopLeftAC()
+            }
 
             if (combo >= 3 && distance >= 3.2f && mc.thePlayer.onGround) {
                 Movement.singleJump(RandomUtils.randomIntInRange(100, 150))

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -280,7 +280,6 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.stopLeftAC()
 
         val now = System.currentTimeMillis()
         val distance = EntityUtils.getDistanceNoY(p, opp)
@@ -288,6 +287,16 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         val projectileActive =
             Mouse.isUsingProjectile() || now < projectileGraceUntil || now < pendingProjectileUntil || now < actionLockUntil
+
+        val held = p.heldItem
+        val holdingWeapon = held != null && (held.unlocalizedName.lowercase().contains("sword") || held.unlocalizedName.lowercase().contains("axe"))
+        val shouldAttack = !projectileActive && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
+                holdingWeapon && distance <= 3.5f
+        if (shouldAttack) {
+            Mouse.startLeftAC()
+        } else {
+            Mouse.stopLeftAC()
+        }
 
         val ht = p.hurtTime
         if (ht > 0 && lastHurtTime == 0) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -425,7 +425,6 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.stopLeftAC()
 
         // Sauts de début : ACTIFS EN CONTINU jusqu'au PREMIER brandissage d'ARC
         if (startupJumping) {
@@ -490,6 +489,16 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         val projectileActive =
             Mouse.isUsingProjectile() || now < projectileGraceUntil || now < pendingProjectileUntil || now < actionLockUntil
+
+        val held = p.heldItem
+        val holdingWeapon = held != null && (held.unlocalizedName.lowercase().contains("sword") || held.unlocalizedName.lowercase().contains("axe"))
+        val shouldAttack = !projectileActive && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
+                holdingWeapon && distance <= 3.5f
+        if (shouldAttack) {
+            Mouse.startLeftAC()
+        } else {
+            Mouse.stopLeftAC()
+        }
 
         // Avance / arrêt (avec stick avant)
         if (now < forwardStickUntil) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -108,8 +108,15 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             // tracking ON en continu
             Mouse.startTracking()
 
-            // auto-CPS OFF
-            Mouse.stopLeftAC()
+            val held = mc.thePlayer.heldItem
+            val holdingWeapon = held != null && (held.unlocalizedName.lowercase().contains("sword") || held.unlocalizedName.lowercase().contains("axe"))
+            val shouldAttack = !Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() && !Mouse.rClickDown &&
+                    holdingWeapon && distance <= 3.5f
+            if (shouldAttack) {
+                Mouse.startLeftAC()
+            } else {
+                Mouse.stopLeftAC()
+            }
 
             if (distance > 8.8f) {
                 if (opponent() != null && opponent()!!.heldItem != null && opponent()!!.heldItem.unlocalizedName.lowercase().contains("bow")) {


### PR DESCRIPTION
## Summary
- Toggle autoclicker in Classic, ClassicV2, OP, Boxing and Blitz bots when in melee range and holding a weapon

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c08e1de0c4832983f3860bb9daa2e5