### PR TITLE
Add hit-and-block combat option for sword bots

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -2,6 +2,11 @@ package best.spaghetcodes.kira.bot
 
 import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.bot.player.*
+import best.spaghetcodes.kira.bot.bots.Blitz
+import best.spaghetcodes.kira.bot.bots.Classic
+import best.spaghetcodes.kira.bot.bots.ClassicV2
+import best.spaghetcodes.kira.bot.bots.Combo
+import best.spaghetcodes.kira.bot.bots.OP
 import best.spaghetcodes.kira.core.KeyBindings
 import best.spaghetcodes.kira.utils.*
 import com.google.gson.JsonArray
@@ -130,6 +135,7 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
                                 combo++
                                 opponentCombo = 0
                                 ticksSinceHit = 0
+                                tryHitAndBlock()
                             } else if (mc.thePlayer != null && entity.entityId == mc.thePlayer.entityId) {
                                 onAttacked()
                                 combo = 0
@@ -239,6 +245,20 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
                     }
                 }
             }
+        }
+    }
+
+    private fun tryHitAndBlock() {
+        val cfg = kira.config ?: return
+        if (cfg.enableHits != true || cfg.enableHitAndBlock != true) return
+        val bot = kira.bot
+        if (bot !is Classic && bot !is ClassicV2 && bot !is Combo && bot !is OP && bot !is Blitz) return
+        val held = mc.thePlayer?.heldItem
+        if (held?.unlocalizedName?.lowercase()?.contains("sword") != true) return
+        val chance = cfg.hitAndBlockChance
+        if (chance <= 0) return
+        if (RandomUtils.randomIntInRange(1, 100) <= chance) {
+            Mouse.rClick(RandomUtils.randomIntInRange(40, 80))
         }
     }
 

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -52,6 +52,12 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
     @Property(type = PropertyType.SWITCH, name = "Enable Kira Hits", description = "Whether the bot should perform hits.", category = "Combat")
     var enableHits = true
 
+    @Property(type = PropertyType.SWITCH, name = "Enable Hit & Block", description = "After a hit, briefly block with the sword.", category = "Combat")
+    var enableHitAndBlock = false
+
+    @Property(type = PropertyType.SLIDER, name = "Hit & Block Chance", description = "Chance in percent to block after a hit.", category = "Combat", min = 0, max = 100)
+    var hitAndBlockChance = 0
+
     @Property(type = PropertyType.SLIDER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25)
     var minCPS = 15
 
@@ -163,6 +169,8 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
         addDependency("ggDelay", "sendAutoGG")
         addDependency("startMessage", "sendStartMessage")
         addDependency("startMessageDelay", "sendStartMessage")
+        addDependency("enableHitAndBlock", "enableHits")
+        addDependency("hitAndBlockChance", "enableHitAndBlock")
         addDependency("dodgeWins", "enableDodging")
         addDependency("dodgeWS", "enableDodging")
         addDependency("dodgeWLR", "enableDodging")

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -292,6 +292,8 @@ class CustomConfigGUI : GuiScreen() {
         val cfg = kira.config ?: return y
 
         toggle("Enable Kira Hits", x, y, { cfg.enableHits }, { cfg.enableHits = it }); y += 20
+        toggle("Enable Hit & Block", x, y, { cfg.enableHitAndBlock }, { cfg.enableHitAndBlock = it }); y += 20
+        number("Hit & Block Chance (%)", x, y, { cfg.hitAndBlockChance }, { cfg.hitAndBlockChance = it }, 0, 100, 1); y += 24
         number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 0, 25, 1); y += 20
         number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 0, 25, 1); y += 24
 


### PR DESCRIPTION
## Summary
- add optional Hit & Block feature after Kira hits
- allow configuring chance for hit-and-block in combat settings
- trigger quick block after confirmed hits for sword dueling bots

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0949e8ac48329a3f9ec62a89b63ab