### PR TITLE
Add hit-and-block combat option for sword bots

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -2,6 +2,11 @@ package best.spaghetcodes.kira.bot
 
 import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.bot.player.*
+import best.spaghetcodes.kira.bot.bots.Blitz
+import best.spaghetcodes.kira.bot.bots.Classic
+import best.spaghetcodes.kira.bot.bots.ClassicV2
+import best.spaghetcodes.kira.bot.bots.Combo
+import best.spaghetcodes.kira.bot.bots.OP
 import best.spaghetcodes.kira.core.KeyBindings
 import best.spaghetcodes.kira.utils.*
 import com.google.gson.JsonArray
@@ -17,6 +22,7 @@ import net.minecraft.client.multiplayer.GuiConnecting
 import net.minecraft.client.multiplayer.ServerData
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.network.Packet
+import net.minecraft.network.play.server.S0BPacketAnimation
 import net.minecraft.network.play.server.S19PacketEntityStatus
 import net.minecraft.network.play.server.S3EPacketTeams
 import net.minecraft.network.play.server.S45PacketTitle
@@ -125,17 +131,18 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
                         val entity = packet.getEntity(mc.theWorld)
                         if (entity != null) {
                             if (entity.entityId == attackedID) {
-                                attackedID = -1
-                                onAttack()
-                                combo++
-                                opponentCombo = 0
-                                ticksSinceHit = 0
+                                confirmAttack()
                             } else if (mc.thePlayer != null && entity.entityId == mc.thePlayer.entityId) {
                                 onAttacked()
                                 combo = 0
                                 opponentCombo++
                             }
                         }
+                    }
+                }
+                is S0BPacketAnimation -> {
+                    if (packet.animationType == 1 && packet.entityId == attackedID) {
+                        confirmAttack()
                     }
                 }
                 is S3EPacketTeams -> {
@@ -242,9 +249,33 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
         }
     }
 
+    private fun confirmAttack() {
+        attackedID = -1
+        onAttack()
+        combo++
+        opponentCombo = 0
+        ticksSinceHit = 0
+        tryHitAndBlock()
+    }
+
+    private fun tryHitAndBlock() {
+        val cfg = kira.config ?: return
+        if (cfg.enableHits != true || cfg.enableHitAndBlock != true) return
+        val bot = kira.bot
+        if (bot !is Classic && bot !is ClassicV2 && bot !is Combo && bot !is OP && bot !is Blitz) return
+        val held = mc.thePlayer?.heldItem
+        if (held?.unlocalizedName?.lowercase()?.contains("sword") != true) return
+        val chance = (cfg.hitAndBlockChance / 5) * 5
+        if (chance <= 0) return
+        if (RandomUtils.randomIntInRange(1, 100) <= chance) {
+            Mouse.rClick(RandomUtils.randomIntInRange(40, 80))
+            ChatUtils.info("hit and block")
+        }
+    }
+
     @SubscribeEvent
     fun onAttackEntityEvent(ev: AttackEntityEvent) {
-        if (toggled() && ev.entity == mc.thePlayer) {
+        if (toggled() && ev.entityPlayer == mc.thePlayer) {
             if (kira.config?.enableHits != true) {
                 ev.isCanceled = true
             } else {

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -52,6 +52,20 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
     @Property(type = PropertyType.SWITCH, name = "Enable Kira Hits", description = "Whether the bot should perform hits.", category = "Combat")
     var enableHits = true
 
+    @Property(type = PropertyType.SWITCH, name = "Enable Hit & Block", description = "After a hit, briefly block with the sword.", category = "Combat")
+    var enableHitAndBlock = false
+
+    @Property(
+        type = PropertyType.NUMBER,
+        name = "Hit & Block Chance",
+        description = "Chance in percent to block after a hit.",
+        category = "Combat",
+        min = 0,
+        max = 100,
+        increment = 5
+    )
+    var hitAndBlockChance = 0
+
     @Property(type = PropertyType.SLIDER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25)
     var minCPS = 15
 
@@ -163,6 +177,8 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
         addDependency("ggDelay", "sendAutoGG")
         addDependency("startMessage", "sendStartMessage")
         addDependency("startMessageDelay", "sendStartMessage")
+        addDependency("enableHitAndBlock", "enableHits")
+        addDependency("hitAndBlockChance", "enableHitAndBlock")
         addDependency("dodgeWins", "enableDodging")
         addDependency("dodgeWS", "enableDodging")
         addDependency("dodgeWLR", "enableDodging")

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -292,6 +292,8 @@ class CustomConfigGUI : GuiScreen() {
         val cfg = kira.config ?: return y
 
         toggle("Enable Kira Hits", x, y, { cfg.enableHits }, { cfg.enableHits = it }); y += 20
+        toggle("Enable Hit & Block", x, y, { cfg.enableHitAndBlock }, { cfg.enableHitAndBlock = it }); y += 20
+        number("Hit & Block Chance (%)", x, y, { cfg.hitAndBlockChance }, { cfg.hitAndBlockChance = it }, 0, 100, 5); y += 24
         number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 0, 25, 1); y += 20
         number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 0, 25, 1); y += 24
 


### PR DESCRIPTION
## Summary
- trigger Hit & Block only after confirmed sword hits by listening for entity status and animation packets
- round Hit & Block chance to 5% steps and expose it with 5% increments in config and GUI
- show chat cue when Hit & Block runs

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c0949e8ac48329a3f9ec62a89b63ab