### PR TITLE
Adjust hit & block chance step size

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -55,7 +55,7 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
     @Property(type = PropertyType.SWITCH, name = "Enable Hit & Block", description = "After a hit, briefly block with the sword.", category = "Combat")
     var enableHitAndBlock = false
 
-    @Property(type = PropertyType.SLIDER, name = "Hit & Block Chance", description = "Chance in percent to block after a hit.", category = "Combat", min = 0, max = 100)
+    @Property(type = PropertyType.SLIDER, name = "Hit & Block Chance", description = "Chance in percent to block after a hit.", category = "Combat", min = 0, max = 100, increment = 5)
     var hitAndBlockChance = 0
 
     @Property(type = PropertyType.SLIDER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25)

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -293,7 +293,7 @@ class CustomConfigGUI : GuiScreen() {
 
         toggle("Enable Kira Hits", x, y, { cfg.enableHits }, { cfg.enableHits = it }); y += 20
         toggle("Enable Hit & Block", x, y, { cfg.enableHitAndBlock }, { cfg.enableHitAndBlock = it }); y += 20
-        number("Hit & Block Chance (%)", x, y, { cfg.hitAndBlockChance }, { cfg.hitAndBlockChance = it }, 0, 100, 1); y += 24
+        number("Hit & Block Chance (%)", x, y, { cfg.hitAndBlockChance }, { cfg.hitAndBlockChance = it }, 0, 100, 5); y += 24
         number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 0, 25, 1); y += 20
         number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 0, 25, 1); y += 24
 


### PR DESCRIPTION
## Summary
- Use 5% increments for Hit & Block Chance selector
- Set config property to save Hit & Block Chance in 5% steps

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c09e65287c8329a40d8abf10014ce5