### PR TITLE
Fix hit and block feature not triggering block

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -149,7 +149,9 @@ object Mouse {
     private fun rClickDown() {
         if (kira.bot?.toggled() == true) {
             rClickDown = true
-            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindUseItem.keyCode, true)
+            val key = kira.mc.gameSettings.keyBindUseItem.keyCode
+            KeyBinding.setKeyBindState(key, true)
+            KeyBinding.onTick(key)
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure Mouse.rClick triggers a right-click tick so hit-and-block works

## Testing
- ⚠️ `./gradlew build` (failed: Unable to tunnel through proxy - HTTP/1.1 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c09f845dd8832984d41206e835a9c0