### PR TITLE
Cast speed and regen potions at game start

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -48,6 +48,17 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
         Movement.startSprinting()
         Movement.startForward()
         TimeUtils.setTimeout(Movement::startJumping, RandomUtils.randomIntInRange(400, 1200))
+
+        useSplashPotion(speedDamage, false, false)
+        speedPotsLeft--
+        lastSpeedUse = System.currentTimeMillis()
+
+        TimeUtils.setTimeout({
+            useSplashPotion(regenDamage, false, false)
+            regenPotsLeft--
+            lastRegenUse = System.currentTimeMillis()
+        }, RandomUtils.randomIntInRange(800, 1200))
+
         Mouse.stopLeftAC()
     }
 


### PR DESCRIPTION
## Summary
- Cast a speed splash potion as soon as the game starts
- Queue a regeneration splash potion shortly after the speed potion

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b56a89dc8329a03aef1494f5b39b