### PR TITLE
Add configurable look randomization distance threshold

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -185,6 +185,8 @@ object Mouse {
             var rotations = EntityUtils.getRotations(kira.mc.thePlayer, kira.bot?.opponent(), false)
 
             if (rotations != null) {
+                val distance = EntityUtils.getDistanceNoY(kira.mc.thePlayer, kira.bot?.opponent()!!)
+
                 if (_runningAway) {
                     if (runningRotations == null) {
                         runningRotations = rotations
@@ -200,13 +202,15 @@ object Mouse {
                     _usingProjectile &&
                     kira.mc.thePlayer?.heldItem?.unlocalizedName?.lowercase()?.contains("pearl") == true
                 ) {
-                    val dist = EntityUtils.getDistanceNoY(kira.mc.thePlayer, kira.bot?.opponent()!!)
-                    rotations[1] -= dist * 0.8f
+                    rotations[1] -= distance * 0.8f
                 }
 
                 val lookRand = (kira.config?.lookRand ?: 0).toDouble()
-                var dyaw = ((rotations[0] - kira.mc.thePlayer.rotationYaw) + RandomUtils.randomDoubleInRange(-lookRand, lookRand)).toFloat()
-                var dpitch = ((rotations[1] - kira.mc.thePlayer.rotationPitch) + RandomUtils.randomDoubleInRange(-lookRand, lookRand)).toFloat()
+                val minDist = (kira.config?.lookRandMinDistance ?: 5).toFloat()
+                val randYaw = if (distance >= minDist) RandomUtils.randomDoubleInRange(-lookRand, lookRand) else 0.0
+                val randPitch = if (distance >= minDist) RandomUtils.randomDoubleInRange(-lookRand, lookRand) else 0.0
+                var dyaw = ((rotations[0] - kira.mc.thePlayer.rotationYaw) + randYaw).toFloat()
+                var dpitch = ((rotations[1] - kira.mc.thePlayer.rotationPitch) + randPitch).toFloat()
 
                 // Compensation de pitch quand l'arc est bandé
                 val bowOffset =
@@ -216,7 +220,7 @@ object Mouse {
                     else 0f
                 dpitch -= bowOffset
 
-                val factor = when (EntityUtils.getDistanceNoY(kira.mc.thePlayer, kira.bot?.opponent()!!)) {
+                val factor = when (distance) {
                     in 0f..10f -> 1.0f
                     in 10f..20f -> 0.6f
                     in 20f..30f -> 0.4f

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -73,6 +73,9 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
     @Property(type = PropertyType.DECIMAL_SLIDER, name = "Look Randomization", description = "Random offset added to view movement.", category = "Combat", minF = 0f, maxF = 2f)
     var lookRand = 0.3f
 
+    @Property(type = PropertyType.NUMBER, name = "Look Rand Min Distance", description = "Minimum distance for look randomization.", category = "Combat", min = 0, max = 20, increment = 1)
+    var lookRandMinDistance = 5
+
     @Property(type = PropertyType.NUMBER, name = "Max Look Distance", description = "Max distance for tracking.", category = "Combat", min = 10, max = 200, increment = 5)
     var maxDistanceLook = 150
 

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -300,6 +300,7 @@ class CustomConfigGUI : GuiScreen() {
         number("Horizontal Look Speed", x, y, { cfg.lookSpeedHorizontal }, { cfg.lookSpeedHorizontal = it }, 1, 50, 1); y += 20
         number("Vertical Look Speed", x, y, { cfg.lookSpeedVertical }, { cfg.lookSpeedVertical = it }, 1, 50, 1); y += 20
         decimal("Look Randomization", x, y, { cfg.lookRand }, { cfg.lookRand = it }, 0f, 2f, 0.05f); y += 24
+        number("Look Rand Min Distance", x, y, { cfg.lookRandMinDistance }, { cfg.lookRandMinDistance = it }, 0, 20, 1); y += 20
         number("Max Look Distance", x, y, { cfg.maxDistanceLook }, { cfg.maxDistanceLook = it }, 10, 200, 5); y += 20
         number("Max Attack Distance", x, y, { cfg.maxDistanceAttack }, { cfg.maxDistanceAttack = it }, 3, 6, 1); y += 24
 


### PR DESCRIPTION
## Summary
- add configurable minimum distance before applying random yaw/pitch offsets
- expose new `lookRandMinDistance` setting in combat config GUI

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c0bdc2a7548329a9ae5d6189cab68e