### PR TITLE
Scale look randomization with distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ Optimisé pour la 1.8.9, il combine **mécaniques de combat** avancées, **autom
 ### 🎯 Combat Intelligent
 - **Smart Aim** — visée prédictive avec compensation de latence  
 - **Smart Strafe** — *(en cours de dev)*  
-- **W-Tap optimisé** — timings de recul et d’engage  
+- **W-Tap optimisé** — timings de recul et d’engage
 - **Combo System** — enchaînements intelligents
+- **Distance-based Look Randomization** — moins de jitter à courte portée, effet complet à longue distance
 
 ### 🛡️ Sécurité & Furtivité
-- **Anti-détection**  
+- **Anti-détection**
 - **Randomisation** des actions (human-like)
 - **Masquage** dans la liste des mods
 
@@ -109,6 +110,8 @@ Combat:
   Lobby Movement: true
   Fast Requeue: true
 ```
+
+> Par défaut, la randomisation démarre à 5 blocs et atteint son effet maximal à 15 blocs.
 
 ---
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -207,8 +207,11 @@ object Mouse {
 
                 val lookRand = (kira.config?.lookRand ?: 0).toDouble()
                 val minDist = (kira.config?.lookRandMinDistance ?: 5).toFloat()
-                val randYaw = if (distance >= minDist) RandomUtils.randomDoubleInRange(-lookRand, lookRand) else 0.0
-                val randPitch = if (distance >= minDist) RandomUtils.randomDoubleInRange(-lookRand, lookRand) else 0.0
+                val maxDist = (kira.config?.lookRandMaxDistance ?: 15).toFloat()
+                val scale = if (maxDist <= minDist) 1f
+                else ((distance - minDist) / (maxDist - minDist)).coerceIn(0f, 1f)
+                val randYaw = RandomUtils.randomDoubleInRange(-lookRand, lookRand) * scale
+                val randPitch = RandomUtils.randomDoubleInRange(-lookRand, lookRand) * scale
                 var dyaw = ((rotations[0] - kira.mc.thePlayer.rotationYaw) + randYaw).toFloat()
                 var dpitch = ((rotations[1] - kira.mc.thePlayer.rotationPitch) + randPitch).toFloat()
 

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -70,11 +70,14 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
     @Property(type = PropertyType.NUMBER, name = "Vertical Look Speed", description = "Vertical look speed.", category = "Combat", min = 1, max = 50, increment = 1)
     var lookSpeedVertical = 5
 
-    @Property(type = PropertyType.DECIMAL_SLIDER, name = "Look Randomization", description = "Random offset added to view movement.", category = "Combat", minF = 0f, maxF = 2f)
+    @Property(type = PropertyType.DECIMAL_SLIDER, name = "Look Randomization", description = "Maximum random offset added to view movement (scaled by distance).", category = "Combat", minF = 0f, maxF = 2f)
     var lookRand = 0.3f
 
-    @Property(type = PropertyType.NUMBER, name = "Look Rand Min Distance", description = "Minimum distance for look randomization.", category = "Combat", min = 0, max = 20, increment = 1)
+    @Property(type = PropertyType.NUMBER, name = "Look Rand Min Distance", description = "Distance where look randomization begins.", category = "Combat", min = 0, max = 20, increment = 1)
     var lookRandMinDistance = 5
+
+    @Property(type = PropertyType.NUMBER, name = "Look Rand Max Distance", description = "Distance where look randomization reaches full strength.", category = "Combat", min = 5, max = 40, increment = 1)
+    var lookRandMaxDistance = 15
 
     @Property(type = PropertyType.NUMBER, name = "Max Look Distance", description = "Max distance for tracking.", category = "Combat", min = 10, max = 200, increment = 5)
     var maxDistanceLook = 150

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -301,6 +301,7 @@ class CustomConfigGUI : GuiScreen() {
         number("Vertical Look Speed", x, y, { cfg.lookSpeedVertical }, { cfg.lookSpeedVertical = it }, 1, 50, 1); y += 20
         decimal("Look Randomization", x, y, { cfg.lookRand }, { cfg.lookRand = it }, 0f, 2f, 0.05f); y += 24
         number("Look Rand Min Distance", x, y, { cfg.lookRandMinDistance }, { cfg.lookRandMinDistance = it }, 0, 20, 1); y += 20
+        number("Look Rand Max Distance", x, y, { cfg.lookRandMaxDistance }, { cfg.lookRandMaxDistance = it }, 5, 40, 1); y += 20
         number("Max Look Distance", x, y, { cfg.maxDistanceLook }, { cfg.maxDistanceLook = it }, 10, 200, 5); y += 20
         number("Max Attack Distance", x, y, { cfg.maxDistanceAttack }, { cfg.maxDistanceAttack = it }, 3, 6, 1); y += 24
 


### PR DESCRIPTION
## Summary
- Scale yaw/pitch jitter based on distance to opponent
- Allow configuring minimum and maximum distance for randomization
- Document distance-based look randomization in README

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bef6166c8329ab39b56c067d98e6