### PR TITLE
Disable random look jitter in close combat

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -186,6 +186,7 @@ object Mouse {
 
             if (rotations != null) {
                 val distance = EntityUtils.getDistanceNoY(kira.mc.thePlayer, kira.bot?.opponent()!!)
+                val closeCombat = distance <= 3.5f
 
                 if (_runningAway) {
                     if (runningRotations == null) {
@@ -216,6 +217,10 @@ object Mouse {
                 else RandomUtils.randomDoubleInRange(-lookRand, lookRand) * scale
                 var randPitch = if (isBowAiming) 0.0
                 else RandomUtils.randomDoubleInRange(-lookRand, lookRand) * scale
+                if (closeCombat) {
+                    randYaw = 0.0
+                    randPitch = 0.0
+                }
                 var dyaw = ((rotations[0] - kira.mc.thePlayer.rotationYaw) + randYaw).toFloat()
                 var dpitch = ((rotations[1] - kira.mc.thePlayer.rotationPitch) + randPitch).toFloat()
 


### PR DESCRIPTION
## Summary
- remove random camera jitter when within 3.5 blocks of opponent by zeroing yaw/pitch adjustments

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c14a73136883299e3821ce7bb2c73f