### PR TITLE
Use Minecraft scheduler for timed tasks

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -36,7 +36,6 @@ import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientConnectedToSe
 import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientDisconnectionFromServerEvent
 import java.math.RoundingMode
 import java.text.DecimalFormat
-import java.util.Timer
 import kotlin.concurrent.thread
 
 open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
@@ -57,14 +56,14 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
     private var playersLost: ArrayList<String> = arrayListOf()
 
     private var opponent: EntityPlayer? = null
-    private var opponentTimer: Timer? = null
+    private var opponentTimer: TimeUtils.Task? = null
     private var calledFoundOpponent = false
 
     protected var combo = 0
     protected var opponentCombo = 0
     protected var ticksSinceHit = 0
 
-    private var reconnectTimer: Timer? = null
+    private var reconnectTimer: TimeUtils.Task? = null
 
     private var ticksSinceGameStart = 0
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
@@ -11,7 +11,6 @@ import best.spaghetcodes.kira.bot.player.Movement
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
-import java.util.*
 import kotlin.math.abs
 
 class Boxing : BotBase("/play duels_boxing_duel"), MovePriority {
@@ -31,7 +30,7 @@ class Boxing : BotBase("/play duels_boxing_duel"), MovePriority {
     }
 
     private var tapping = false
-    private var fishTimer: Timer? = null
+    private var fishTimer: TimeUtils.Task? = null
 
     override fun onGameStart() {
         Movement.startSprinting()

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
@@ -7,14 +7,13 @@ import best.spaghetcodes.kira.utils.TimeUtils
 import best.spaghetcodes.kira.utils.WorldUtils
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent
-import java.util.Timer
 
 object LobbyMovement {
 
     private var tickYawChange = 0f
     private var initialYaw = 0f
     private var lastDirectionChange = 0L
-    private var intervals: ArrayList<Timer?> = ArrayList()
+    private var intervals: ArrayList<TimeUtils.Task?> = ArrayList()
 
     fun sumo() {
         /*val opt = RandomUtils.randomIntInRange(0, 1)

--- a/src/main/kotlin/best/spaghetcodes/kira/utils/TimeUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/TimeUtils.kt
@@ -1,47 +1,49 @@
 package best.spaghetcodes.kira.utils
 
-import java.util.*
+import net.minecraft.client.Minecraft
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 
 object TimeUtils {
+
+    private val scheduler = Executors.newSingleThreadScheduledExecutor()
+
+    class Task internal constructor(private val future: ScheduledFuture<*>) {
+        fun cancel() {
+            future.cancel(false)
+        }
+    }
 
     /**
      * Call a function after delay ms
      */
-    fun setTimeout(function: () -> Unit, delay: Int): Timer? {
-        try {
-            val timer = Timer()
-            timer.schedule(
-                object : TimerTask() {
-                    override fun run() {
-                        function()
-                    }
-                }, delay.toLong()
-            )
-            return timer
+    fun setTimeout(function: () -> Unit, delay: Int): Task? {
+        return try {
+            val future = scheduler.schedule({
+                Minecraft.getMinecraft().addScheduledTask(function)
+            }, delay.toLong(), TimeUnit.MILLISECONDS)
+            Task(future)
         } catch (e: Exception) {
-            println("Error scheduling timer with ${delay}ms: " + e.message)
+            println("Error scheduling timeout with ${delay}ms: " + e.message)
+            null
         }
-        return null
     }
 
     /**
      * Call a function every interval ms after delay ms
      */
-    fun setInterval(function: () -> Unit, delay: Int, interval: Int): Timer? {
-        try {
-            val timer = Timer()
-            timer.schedule(
-                object : TimerTask() {
-                    override fun run() {
-                        function()
-                    }
-                }, delay.toLong(), interval.toLong()
-            )
-            return timer
+    fun setInterval(function: () -> Unit, delay: Int, interval: Int): Task? {
+        return try {
+            val future = scheduler.scheduleAtFixedRate({
+                Minecraft.getMinecraft().addScheduledTask(function)
+            }, delay.toLong(), interval.toLong(), TimeUnit.MILLISECONDS)
+            Task(future)
         } catch (e: Exception) {
-            println("Error scheduling timer with ${delay}ms delay and ${interval}m interval: " + e.message)
+            println(
+                "Error scheduling interval with ${delay}ms delay and ${interval}ms interval: " + e.message
+            )
+            null
         }
-        return null
     }
-
 }


### PR DESCRIPTION
## Summary
- replace java Timer-based scheduling with Minecraft thread-safe scheduler
- update bot systems to use new cancellable Task handles

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_68c16c125d088329a99fe14453c85694