### PR TITLE
Ensure left click persists for a full tick

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -63,8 +63,11 @@ object Mouse {
             kira.mc.thePlayer != null &&
             !kira.mc.thePlayer.isUsingItem
         ) {
+            leftClickDur = 2
             kira.mc.thePlayer.swingItem()
-            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindAttack.keyCode, true)
+            val key = kira.mc.gameSettings.keyBindAttack.keyCode
+            KeyBinding.setKeyBindState(key, true)
+            KeyBinding.onTick(key)
             if (kira.mc.objectMouseOver != null && kira.mc.objectMouseOver.entityHit != null) {
                 kira.mc.playerController.attackEntity(kira.mc.thePlayer, kira.mc.objectMouseOver.entityHit)
             }
@@ -168,6 +171,8 @@ object Mouse {
         if (kira.mc.thePlayer != null && kira.bot?.toggled() == true) {
             if (leftAC) leftACFunc()
             if (leftClickDur > 0) {
+                val key = kira.mc.gameSettings.keyBindAttack.keyCode
+                KeyBinding.onTick(key)
                 leftClickDur--
             } else {
                 KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindAttack.keyCode, false)


### PR DESCRIPTION
## Summary
- Keep left click pressed for two ticks and simulate key hold via `KeyBinding.onTick`
- Tick handler now decrements duration after forwarding the tick event, preventing early release

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c16d8fd6108329a117f74464d0bf78