### PR TITLE
Respect enableHits in all bots

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -6,6 +6,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -71,7 +72,8 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
         val distance = EntityUtils.getDistanceNoY(p, opp)
         val held = p.heldItem
         val holdingWeapon = held != null && (held.unlocalizedName.lowercase().contains("sword") || held.unlocalizedName.lowercase().contains("axe"))
-        val shouldAttack = !Mouse.isUsingProjectile() && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
+        val shouldAttack = kira.config?.enableHits == true &&
+                !Mouse.isUsingProjectile() && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
                 holdingWeapon && distance <= 3.5f
         if (shouldAttack) {
             Mouse.startLeftAC()

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
@@ -82,7 +82,8 @@ class Boxing : BotBase("/play duels_boxing_duel"), MovePriority {
 
             val held = mc.thePlayer.heldItem
             val holdingWeapon = held != null && !held.unlocalizedName.lowercase().contains("bow") && !held.unlocalizedName.lowercase().contains("rod")
-            val shouldAttack = !Mouse.isUsingProjectile() && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
+            val shouldAttack = kira.config?.enableHits == true &&
+                    !Mouse.isUsingProjectile() && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
                     holdingWeapon && distance <= 3.5f
             if (shouldAttack) {
                 Mouse.startLeftAC()

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -8,6 +8,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import best.spaghetcodes.kira.utils.ChatUtils
 import net.minecraft.init.Blocks
@@ -290,7 +291,8 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         val held = p.heldItem
         val holdingWeapon = held != null && (held.unlocalizedName.lowercase().contains("sword") || held.unlocalizedName.lowercase().contains("axe"))
-        val shouldAttack = !projectileActive && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
+        val shouldAttack = kira.config?.enableHits == true &&
+                !projectileActive && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
                 holdingWeapon && distance <= 3.5f
         if (shouldAttack) {
             Mouse.startLeftAC()

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -492,7 +492,8 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         val held = p.heldItem
         val holdingWeapon = held != null && (held.unlocalizedName.lowercase().contains("sword") || held.unlocalizedName.lowercase().contains("axe"))
-        val shouldAttack = !projectileActive && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
+        val shouldAttack = kira.config?.enableHits == true &&
+                !projectileActive && !Mouse.isUsingPotion() && !Mouse.isRunningAway() && !Mouse.rClickDown &&
                 holdingWeapon && distance <= 3.5f
         if (shouldAttack) {
             Mouse.startLeftAC()

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -7,6 +7,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -110,7 +111,8 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
 
             val held = mc.thePlayer.heldItem
             val holdingWeapon = held != null && (held.unlocalizedName.lowercase().contains("sword") || held.unlocalizedName.lowercase().contains("axe"))
-            val shouldAttack = !Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() && !Mouse.rClickDown &&
+            val shouldAttack = kira.config?.enableHits == true &&
+                    !Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() && !Mouse.rClickDown &&
                     holdingWeapon && distance <= 3.5f
             if (shouldAttack) {
                 Mouse.startLeftAC()

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Sumo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Sumo.kt
@@ -5,6 +5,7 @@ import best.spaghetcodes.kira.bot.features.MovePriority
 import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -149,7 +150,7 @@ class Sumo : BotBase("/play duels_sumo_duel"), MovePriority {
                 && !isHitselecting && approaching
                 && distance <= prefireFastApproachDist && distance > attackStartDist)
 
-        if (inAttackLatch || inPrefire) {
+        if (kira.config?.enableHits == true && (inAttackLatch || inPrefire)) {
             val latch = if (inPrefire) prefireLatchMs else attackLatchMs
             keepACUntil = now + latch
             Mouse.startLeftAC()


### PR DESCRIPTION
## Summary
- ensure each bot checks `enableHits` before starting attack logic
- allow disabling hits across all game modes

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c1870f711c83299ffc83c63a04f30e