### PR TITLE
Smooth small yaw corrections and delay aim after strafe swap

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -28,6 +28,8 @@ object Mouse {
 
     private var splashAim = 0.0
 
+    private var aimBlockTicks = 0
+
     // ---- Bow ballistic compensation (pitch) ----
     private fun bowDistanceToOpponent(): Float {
         val p = kira.mc.thePlayer ?: return 0f
@@ -133,6 +135,10 @@ object Mouse {
         return _runningAway
     }
 
+    fun blockAim(ticks: Int) {
+        aimBlockTicks = ticks
+    }
+
     private fun leftACFunc() {
         if (kira.bot?.toggled() == true && kira.config?.enableHits == true && leftAC) {
             if (!kira.mc.thePlayer.isUsingItem) {
@@ -181,6 +187,10 @@ object Mouse {
             }
         }
         if (kira.mc.thePlayer != null && kira.bot?.toggled() == true && tracking && kira.bot?.opponent() != null) {
+            if (aimBlockTicks > 0) {
+                aimBlockTicks--
+                return
+            }
             if (rClickDown &&
                 kira.mc.thePlayer?.heldItem?.unlocalizedName?.lowercase()?.contains("bow") == true
             ) {
@@ -239,6 +249,10 @@ object Mouse {
 
                 var dyaw = (exactYaw + randYaw).toFloat()
                 var dpitch = (exactPitch + randPitch).toFloat()
+
+                if (abs(exactYaw) < 2f) {
+                    dyaw /= 3f
+                }
 
                 // Compensation de pitch quand l'arc est bandé
                 val bowOffset = if (isBowAiming) bowPitchComp(bowDistanceToOpponent()) else 0f

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Movement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Movement.kt
@@ -140,6 +140,7 @@ object Movement {
             stopRight()
             startLeft()
         }
+        Mouse.blockAim(RandomUtils.randomIntInRange(1, 2))
     }
 
     fun forward(): Boolean {


### PR DESCRIPTION
## Summary
- Smooth yaw adjustments under 2° to prevent micro-corrections
- Pause aiming for 1–2 ticks after swapping strafe direction to avoid snap back

## Testing
- `gradle build` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.7.10'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b90ecca483298d7656031a6417ff