### PR TITLE
Use main-thread scheduled tasks

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/Kira.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/Kira.kt
@@ -10,6 +10,7 @@ import best.spaghetcodes.kira.core.Config
 import best.spaghetcodes.kira.core.KeyBindings
 import best.spaghetcodes.kira.gui.StatsOverlay
 import best.spaghetcodes.kira.events.packet.PacketListener
+import best.spaghetcodes.kira.utils.TimeUtils
 import com.google.gson.Gson
 import net.minecraft.client.Minecraft
 import net.minecraftforge.common.MinecraftForge
@@ -59,6 +60,7 @@ class kira {
         MinecraftForge.EVENT_BUS.register(LobbyMovement)
         MinecraftForge.EVENT_BUS.register(KeyBindings)
         MinecraftForge.EVENT_BUS.register(StatsOverlay())
+        MinecraftForge.EVENT_BUS.register(TimeUtils)
 
         // Utilise l’accès typé -> aucun Any ici.
         val idx = config?.currentBot ?: 0

--- a/src/main/kotlin/best/spaghetcodes/kira/utils/TimeUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/TimeUtils.kt
@@ -1,17 +1,20 @@
 package best.spaghetcodes.kira.utils
 
 import net.minecraft.client.Minecraft
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import net.minecraftforge.fml.common.gameevent.TickEvent
+import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent
+import java.util.concurrent.CopyOnWriteArrayList
 
 object TimeUtils {
 
-    private val scheduler = Executors.newSingleThreadScheduledExecutor()
+    private class ScheduledTask(var nextRun: Long, val interval: Long?, val function: () -> Unit)
 
-    class Task internal constructor(private val future: ScheduledFuture<*>) {
+    private val tasks = CopyOnWriteArrayList<ScheduledTask>()
+
+    class Task internal constructor(private val scheduled: ScheduledTask) {
         fun cancel() {
-            future.cancel(false)
+            tasks.remove(scheduled)
         }
     }
 
@@ -19,31 +22,34 @@ object TimeUtils {
      * Call a function after delay ms
      */
     fun setTimeout(function: () -> Unit, delay: Int): Task? {
-        return try {
-            val future = scheduler.schedule({
-                Minecraft.getMinecraft().addScheduledTask(function)
-            }, delay.toLong(), TimeUnit.MILLISECONDS)
-            Task(future)
-        } catch (e: Exception) {
-            println("Error scheduling timeout with ${delay}ms: " + e.message)
-            null
-        }
+        val task = ScheduledTask(System.currentTimeMillis() + delay, null, function)
+        tasks.add(task)
+        return Task(task)
     }
 
     /**
      * Call a function every interval ms after delay ms
      */
     fun setInterval(function: () -> Unit, delay: Int, interval: Int): Task? {
-        return try {
-            val future = scheduler.scheduleAtFixedRate({
-                Minecraft.getMinecraft().addScheduledTask(function)
-            }, delay.toLong(), interval.toLong(), TimeUnit.MILLISECONDS)
-            Task(future)
-        } catch (e: Exception) {
-            println(
-                "Error scheduling interval with ${delay}ms delay and ${interval}ms interval: " + e.message
-            )
-            null
+        val task = ScheduledTask(System.currentTimeMillis() + delay, interval.toLong(), function)
+        tasks.add(task)
+        return Task(task)
+    }
+
+    @SubscribeEvent
+    fun onClientTick(event: ClientTickEvent) {
+        if (event.phase != TickEvent.Phase.END) return
+
+        val now = System.currentTimeMillis()
+        for (task in tasks) {
+            if (task.nextRun <= now) {
+                Minecraft.getMinecraft().addScheduledTask(task.function)
+                if (task.interval != null) {
+                    task.nextRun = now + task.interval
+                } else {
+                    tasks.remove(task)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace background scheduled executor with tick-processed queue that posts work via `Minecraft.getMinecraft().addScheduledTask`
- Register `TimeUtils` with the event bus to execute queued tasks each client tick

## Testing
- ⚠️ `./gradlew build` *(proxy error: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d892eb348329a314ee9a48ac9928