### PR TITLE
Run scheduled tasks on main thread via TickEvent

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/utils/TimeUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/TimeUtils.kt
@@ -1,6 +1,5 @@
 package best.spaghetcodes.kira.utils
 
-import net.minecraft.client.Minecraft
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent
@@ -43,7 +42,7 @@ object TimeUtils {
         val now = System.currentTimeMillis()
         for (task in tasks) {
             if (task.nextRun <= now) {
-                Minecraft.getMinecraft().addScheduledTask(task.function)
+                task.function()
                 if (task.interval != null) {
                     task.nextRun = now + task.interval
                 } else {


### PR DESCRIPTION
## Summary
- Execute `setTimeout` and `setInterval` callbacks directly during `ClientTickEvent` so they run on the main thread.
- Remove unnecessary `Minecraft.addScheduledTask` indirection.

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dc45f94083298287093d7229a98e