### PR TITLE
Fix TimeUtils ScheduledTask visibility

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/utils/TimeUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/TimeUtils.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 
 object TimeUtils {
 
-    private class ScheduledTask(var nextRun: Long, val interval: Long?, val function: () -> Unit)
+    internal class ScheduledTask(var nextRun: Long, val interval: Long?, val function: () -> Unit)
 
     private val tasks = CopyOnWriteArrayList<ScheduledTask>()
 


### PR DESCRIPTION
## Summary
- make `ScheduledTask` internal so public API doesn't expose private type

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c145f489248329b3350c1622edb259