### PR TITLE
chore: suppress unused warnings

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -77,6 +77,7 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
     protected open fun onFoundOpponent() {}
     protected open fun onTick() {}
 
+    @Suppress("UNUSED_PARAMETER")
     protected fun setStatKeys(keys: Map<String, String>) {}
 
     // -------- Résultat via résumé & kill (FR/EN) --------
@@ -190,7 +191,7 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
                                     val me = mc.thePlayer.displayNameString
                                     val p = ChatUtils.removeFormatting(packet.message.unformattedText).split("won")[0].trim()
 
-                                    val (winner, loser, iWon) =
+                                    val (_, _, iWon) =
                                         if (unformatted.contains(me.lowercase())) {
                                             Session.wins++
                                             Triple(me, lastOpponentName, true)

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
@@ -80,7 +80,7 @@ object LobbyMovement {
 
         // Remplace l’ancien “snap 180°” par un DEMI-CERCLE lissé, même intervalle 7000/7000
         intervals.add(TimeUtils.setInterval(fun() {
-            val p = kira.mc.thePlayer ?: return@setInterval
+            kira.mc.thePlayer ?: return@setInterval
 
             // alterner droite/gauche
             ffTurnRight = !ffTurnRight
@@ -330,6 +330,7 @@ object LobbyMovement {
     }
 
     @SubscribeEvent
+    @Suppress("UNUSED_PARAMETER")
     fun onClientTick(event: ClientTickEvent) {
         if (!canActivateAndRunAnyMovement()) {
             if (activeMovementType != null) stop()


### PR DESCRIPTION
## Summary
- silence unused parameter warning in `setStatKeys`
- remove unused winner/loser variables
- drop unused player reference and suppress event parameter warning

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c595ee13148329853e3eb901cb6737