### PR TITLE
Handle French start messages in Sumo detection

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -296,7 +296,8 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
         val unformatted = ev.message.unformattedText
         if (toggled() && mc.thePlayer != null) {
 
-            if (unformatted.contains("The game starts in 1 second!")) {
+            if (unformatted.contains("The game starts in 1 second!") ||
+                unformatted.contains("La partie commence dans 1 seconde")) {
                 beforeStart()
             }
 
@@ -304,7 +305,7 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
                 leaveGame()
             }
 
-            if (unformatted.contains("Opponent:")) {
+            if (unformatted.contains("Opponent:") || unformatted.contains("Adversaire")) {
                 gameStart()
             }
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
@@ -37,7 +37,7 @@ object StateManager {
             if (unformatted.matches(Regex(".* a rejoint \\(2/2\\)!"))) {
                 gameFull = true
             }
-        } else if (unformatted.contains("Opponent:")) {
+        } else if (unformatted.contains("Opponent:") || unformatted.contains("Adversaire")) {
             state = States.PLAYING
             gameStartedAt = System.currentTimeMillis()
             LobbyMovement.stop()


### PR DESCRIPTION
## Summary
- Detect "Adversaire" and French start countdown lines to handle French-language clients

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c59f2a6268832995cdf8fdbb61deae