### PR TITLE
Fix mod logo path

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -11,7 +11,7 @@
             "Nix"
         ],
         "credits": "HumanDuck23",
-        "logoFile": "src/main/resources/logo.png",
+        "logoFile": "logo.png",
         "screenshots": [],
         "dependencies": []
     }


### PR DESCRIPTION
## Summary
- fix logoFile path in mcmod.info so the mod logo can be loaded by Minecraft

## Testing
- `./gradlew build` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden"*)

------
https://chatgpt.com/codex/tasks/task_e_68c5e1c99e048329849d3117d0c6dec6