### PR TITLE
Add delay before eating golden apples

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Gap.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Gap.kt
@@ -18,7 +18,11 @@ interface Gap {
             if (Inventory.setInvItem("gold")) {
                 ChatUtils.info("About to gap")
                 val r = RandomUtils.randomIntInRange(2100, 2200)
-                Mouse.rClick(r)
+                val equipDelay = RandomUtils.randomIntInRange(80, 130)
+
+                TimeUtils.setTimeout(fun () {
+                    Mouse.rClick(r)
+                }, equipDelay)
 
                 TimeUtils.setTimeout(fun () {
                     Inventory.setInvItem("sword")
@@ -26,7 +30,7 @@ interface Gap {
                     TimeUtils.setTimeout(fun () {
                         Mouse.setRunningAway(false)
                     }, RandomUtils.randomIntInRange(200, 400))
-                }, r + RandomUtils.randomIntInRange(200, 300))
+                }, equipDelay + r + RandomUtils.randomIntInRange(200, 300))
             }
         }
 


### PR DESCRIPTION
## Summary
- add small delay after switching to golden apple to ensure consumption starts before returning to sword

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy (HTTP 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c5f5990bd883298f0e9abba2dd18a9