### PR TITLE
Reduce OP gap post-use delay

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -365,7 +365,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             if (!Mouse.isUsingProjectile() && !Mouse.isUsingPotion()) {
                 Inventory.setInvItem("sword")
             }
-        }, RandomUtils.randomIntInRange(3400, 4200))
+        }, RandomUtils.randomIntInRange(2400, 2800))
     }
 
     // =====================  LIFECYCLE  =====================


### PR DESCRIPTION
## Summary
- shorten golden apple timeout in OP mode so bot quickly switches back to sword

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 - proxy returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c602d12abc8329838b07493aca0bbb