### PR TITLE
Avoid wall collisions when splashing second speed potion

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -314,6 +314,41 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
     // COMBAT : 180° lissé → bunny-hop → STOP SAUT → LANCER → délai court → SAUT unique
     private fun retreatAndSplash(damage: Int, onComplete: () -> Unit) {
         if (takingPotion) return
+        val p = mc.thePlayer ?: return
+
+        // If there is no room behind the player, splash without retreating
+        if (!WorldUtils.airInBack(p, 2.0f)) {
+            retreating = true
+            takingPotion = true
+            Mouse.stopLeftAC()
+            Mouse.setUsingProjectile(false)
+
+            val pitch = pickForwardOrSlightUpPitch()
+            smoothFaceAway(totalMsMin = 240, totalMsMax = 340, pitch = pitch)
+            Mouse.stopTracking()
+
+            Movement.stopForward()
+            Movement.stopBackward()
+            Movement.clearLeftRight()
+            Movement.stopJumping()
+
+            val delay = RandomUtils.randomIntInRange(240, 320)
+            TimeUtils.setTimeout({
+                setPitchLock(pitch, lockMs = RandomUtils.randomIntInRange(260, 340))
+                useSplashPotion(damage, false, false)
+                lastPotion = System.currentTimeMillis()
+                onComplete()
+
+                val jumpDelay = RandomUtils.randomIntInRange(160, 220)
+                TimeUtils.setTimeout({
+                    Movement.singleJump(RandomUtils.randomIntInRange(50, 80))
+                    retreating = false
+                    takingPotion = false
+                }, jumpDelay)
+            }, delay)
+            return
+        }
+
         retreating = true
         takingPotion = true
         Mouse.stopLeftAC()


### PR DESCRIPTION
## Summary
- Check for free space behind the player before retreating for a speed potion
- Splash the potion in place when space is blocked to prevent wall collisions

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c60852699c83299115603934a26d9a