### PR TITLE
Maintain camera tracking while gappling in OP mode

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -587,7 +587,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             if (!allowStrafing && hasSpeed && hasRegen) allowStrafing = true
 
             // Tracking caméra
-            if (retreating || takingPotion || now < aimFreezeUntil) Mouse.stopTracking() else Mouse.startTracking()
+            if ((retreating && !eatingGap) || takingPotion || now < aimFreezeUntil) Mouse.stopTracking() else Mouse.startTracking()
 
             if (kira.config?.kiraHit == true && !retreating && !eatingGap && !takingPotion) Mouse.startLeftAC() else Mouse.stopLeftAC()
 


### PR DESCRIPTION
## Summary
- Keep camera tracking active when the OP bot eats a golden apple so it doesn't stop tracking mid-fight

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c66a012944832988b99887f35cb8fd