### PR TITLE
fix: avoid forward/back conflict when gapping in OP mode

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -386,6 +386,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
         if (eatingGap || start < lastGap + MIN_GAP_INTERVAL_MS) return
 
         eatingGap = true
+        Combat.cancelWTap()
         Mouse.stopLeftAC()
         Mouse.setUsingProjectile(false)
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Combat.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Combat.kt
@@ -2,6 +2,7 @@ package best.spaghetcodes.kira.bot.player
 
 import best.spaghetcodes.kira.utils.RandomUtils
 import best.spaghetcodes.kira.utils.TimeUtils
+import java.util.Timer
 
 object Combat {
 
@@ -9,9 +10,21 @@ object Combat {
     private var randomStrafeMin = 0
     private var randomStrafeMax = 0
 
+    private var wTapTimer: Timer? = null
+
     fun wTap(duration: Int) {
         Movement.stopForward()
-        TimeUtils.setTimeout(Movement::startForward, duration)
+        wTapTimer?.cancel()
+        wTapTimer = TimeUtils.setTimeout({
+            Movement.startForward()
+            wTapTimer = null
+        }, duration)
+    }
+
+    fun cancelWTap() {
+        wTapTimer?.cancel()
+        wTapTimer = null
+        Movement.stopForward()
     }
 
     fun sTap(duration: Int) {


### PR DESCRIPTION
## Summary
- cancel pending wTap timers and expose cancelWTap helper
- stop lingering wTap during OP gap retreats to avoid opposing movement keys

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c66caa0a84832997e5140f3951c15c