### PR TITLE
Humanize Kira Hit interactions

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -69,7 +69,7 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     @Property(type = PropertyType.NUMBER, name = "Max Attack Distance", description = "Max distance for attacking.", category = "Combat", min = 3, max = 6, increment = 1)
     var maxDistanceAttack = 5
 
-    @Property(type = PropertyType.SWITCH, name = "Kira Hit", description = "Automatically attack opponents.", category = "Combat")
+    @Property(type = PropertyType.SWITCH, name = "Kira Hit", description = "Automatically attack opponents with human-like timing.", category = "Combat")
     var kiraHit = true
 
     @Property(type = PropertyType.SWITCH, name = "Hit & Block", description = "Briefly block after successful sword hits.", category = "Combat")


### PR DESCRIPTION
## Summary
- Keep Kira Hit's attack loop continuous by varying CPS smoothly with jittered delays
- Schedule clicks with `System.nanoTime` and document nanosecond scheduling
- Bound min/max CPS and centralize timing constants so jitter and hold durations stay sane
- Enforce a minimum click delay so jitter never schedules negative or zero intervals
- Update Kira Hit configuration description to highlight human-like timing

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c682a7db1083298635a7ffb18a4d75