### PR TITLE
Show CPS on stats overlay

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -104,6 +104,10 @@ object Mouse {
         lastCPS = 0
     }
 
+    fun currentCPS(): Int {
+        return lastCPS
+    }
+
     fun startTracking() {
         tracking = true
     }

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/StatsOverlay.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/StatsOverlay.kt
@@ -1,6 +1,7 @@
 package best.spaghetcodes.kira.gui
 
 import best.spaghetcodes.kira.bot.Session
+import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.kira
 import net.minecraft.client.gui.Gui
 import net.minecraftforge.client.event.RenderGameOverlayEvent
@@ -38,6 +39,13 @@ class StatsOverlay {
         if (elapsed > 0) {
             lines += "Wins/h: ${df.format(winsPerHour)}"
             lines += "Time: ${minutes}m"
+        }
+
+        if (kira.config?.kiraHit == true) {
+            val cps = Mouse.currentCPS()
+            if (cps > 0) {
+                lines += "CPS: $cps"
+            }
         }
 
         val fr = mc.fontRendererObj


### PR DESCRIPTION
## Summary
- show active CPS on stats overlay when Kira Hit is enabled
- expose current CPS from Mouse for overlay display

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy - HTTP/1.1 403 Forbidden)*
- `./gradlew build --refresh-dependencies` *(fails: Plugin org.jetbrains.kotlin.jvm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c68de80a4c8329a6afbd70031e821d