### PR TITLE
Customize splash potion messages

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Potion.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Potion.kt
@@ -17,7 +17,12 @@ interface Potion {
         fun pot(dmg: Int) {
             Mouse.stopLeftAC()
             if (Inventory.setInvItemByDamage(dmg)) {
-                ChatUtils.info("About to splash $dmg")
+                val msg = when (dmg) {
+                    16386 -> "Splash Speed"
+                    16385 -> "Splash Regen"
+                    else -> "About to splash $dmg"
+                }
+                ChatUtils.info(msg)
                 TimeUtils.setTimeout(fun() {
                     Mouse.setUsingPotion(true)
 


### PR DESCRIPTION
## Summary
- Map splash potion damage values 16386 and 16385 to chat messages "Splash Speed" and "Splash Regen".

## Testing
- `./gradlew build` *(fails: A problem occurred configuring root project 'Kira'. Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c6916abb4c83299fc845548475325a