### PR TITLE
fix: resume attack when baiting ends in sumo

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Sumo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Sumo.kt
@@ -215,6 +215,19 @@ class Sumo : BotBase("/play duels_sumo_duel"), MovePriority {
             }, baitDur)
         }
 
+        // If the opponent closes in while baiting, stop hitselecting and attack
+        if (isHitselecting && distance <= attackStartDist) {
+            isHitselecting = false
+            hitselectCooldownUntil = now + RandomUtils.randomIntInRange(hitselectCooldown.first, hitselectCooldown.last)
+            if (stoppedSprintForBait && !p.isSprinting) {
+                Movement.startSprinting()
+            }
+            if (kira.config?.kiraHit == true) {
+                keepACUntil = now + attackLatchMs
+                Mouse.startLeftAC()
+            }
+        }
+
         // =================== STRAFE & DIRECTION ===================
         val movePriority = arrayListOf(0, 0)
         var clear = false


### PR DESCRIPTION
## Summary
- cancel hitselecting early in Sumo bot if the opponent is close
- immediately restart autoclick after canceling bait

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c691a2b9e48329b68df04fc319aad8