### PR TITLE
Fix delayed attack after gapping in OP mode

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -404,8 +404,9 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             eatingGap = false
             if (!Mouse.isUsingProjectile() && !Mouse.isUsingPotion()) {
                 Inventory.setInvItem("sword")
+                if (kira.config?.kiraHit == true) Mouse.startLeftAC()
             }
-        }, RandomUtils.randomIntInRange(3400, 4200))
+        }, RandomUtils.randomIntInRange(2600, 3200))
     }
 
     // =====================  LIFECYCLE  =====================


### PR DESCRIPTION
## Summary
- Resume attacking sooner after eating a golden apple in OP duels when Kira Hit is enabled
- Restart auto-click and shorten post-gapple delay

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c6967cfba88329a8c34a7f76a47bb1