### PR TITLE
feat: add flint and steel usage in OP mode

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Flint.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Flint.kt
@@ -1,0 +1,45 @@
+package best.spaghetcodes.kira.bot.features
+
+import best.spaghetcodes.kira.bot.player.Inventory
+import best.spaghetcodes.kira.bot.player.Mouse
+import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
+import best.spaghetcodes.kira.utils.RandomUtils
+import best.spaghetcodes.kira.utils.TimeUtils
+
+/**
+ * Gestion du briquet (flint and steel) pour Hypixel OP.
+ * Place rapidement un feu au sol en regardant vers le bas et en reculant.
+ */
+interface Flint {
+
+    /** Nombre d'utilisations restantes. */
+    var flintUses: Int
+
+    /**
+     * Utilise le briquet si disponible. Le joueur regarde vers le bas (~45°),
+     * recule pendant l'ignition puis exécute le callback [after].
+     */
+    fun useFlint(distance: Float, after: () -> Unit = {}) {
+        if (flintUses <= 0) return
+        if (!Inventory.setInvItem("flint_and_steel")) {
+            after()
+            return
+        }
+
+        flintUses--
+        Mouse.stopLeftAC()
+        kira.mc.thePlayer?.rotationPitch = RandomUtils.randomIntInRange(44, 50).toFloat()
+        Movement.stopForward()
+        Movement.startBackward()
+
+        val clickMs = RandomUtils.randomIntInRange(80, 110)
+        Mouse.rClick(clickMs)
+
+        TimeUtils.setTimeout({
+            Movement.stopBackward()
+            after()
+        }, clickMs + RandomUtils.randomIntInRange(120, 180))
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement Flint feature to ignite blocks while retreating
- integrate flint usage around gapples in OP bot

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c699091dd48329aeae55394f65a909