### PR TITLE
Ensure bot toggle messages always display

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -279,9 +279,15 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
 
         if (KeyBindings.toggleBotKeyBinding.isPressed) {
             toggle()
-            ChatUtils.info("Kira has been toggled ${if (toggled()) "${EnumChatFormatting.GREEN}on" else "${EnumChatFormatting.RED}off"}")
+            ChatUtils.info(
+                "Kira has been toggled ${if (toggled()) "${EnumChatFormatting.GREEN}on" else "${EnumChatFormatting.RED}off"}",
+                force = true
+            )
             if (toggled()) {
-                ChatUtils.info("Current selected bot: ${EnumChatFormatting.GREEN}${getName()}")
+                ChatUtils.info(
+                    "Current selected bot: ${EnumChatFormatting.GREEN}${getName()}",
+                    force = true
+                )
                 joinGame()
                 if (Session.startTime <= 0L) {
                     Session.startTime = System.currentTimeMillis()

--- a/src/main/kotlin/best/spaghetcodes/kira/utils/ChatUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/ChatUtils.kt
@@ -29,18 +29,24 @@ object ChatUtils {
         }
     }
 
-    fun info(message: String) {
+    fun info(message: String, force: Boolean = false) {
         // Prefixe chat changé : [KIRA] en bleu ciel (AQUA)
-        sendChatMessage("${EnumChatFormatting.AQUA}[${EnumChatFormatting.BOLD}KIRA${EnumChatFormatting.RESET}${EnumChatFormatting.AQUA}] ${EnumChatFormatting.WHITE}$message")
+        sendChatMessage(
+            "${EnumChatFormatting.AQUA}[${EnumChatFormatting.BOLD}KIRA${EnumChatFormatting.RESET}${EnumChatFormatting.AQUA}] ${EnumChatFormatting.WHITE}$message",
+            force
+        )
     }
 
-    fun error(message: String) {
+    fun error(message: String, force: Boolean = false) {
         // Même prefixe, message en rouge
-        sendChatMessage("${EnumChatFormatting.AQUA}[${EnumChatFormatting.BOLD}KIRA${EnumChatFormatting.RESET}${EnumChatFormatting.AQUA}] ${EnumChatFormatting.RED}$message")
+        sendChatMessage(
+            "${EnumChatFormatting.AQUA}[${EnumChatFormatting.BOLD}KIRA${EnumChatFormatting.RESET}${EnumChatFormatting.AQUA}] ${EnumChatFormatting.RED}$message",
+            force
+        )
     }
 
-    private fun sendChatMessage(message: String) {
-        if (kira.mc.thePlayer != null && kira.config?.disableChatMessages != true) {
+    private fun sendChatMessage(message: String, force: Boolean = false) {
+        if (kira.mc.thePlayer != null && (force || kira.config?.disableChatMessages != true)) {
             kira.mc.thePlayer.addChatMessage(ChatComponentText(message))
         }
     }


### PR DESCRIPTION
## Summary
- Always show bot toggle status and selected bot in chat
- Allow ChatUtils to force messages even when chat output is disabled

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c6a6dec20083299194023c80374039