### PR TITLE
fix: stop parry before eating gap

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -395,7 +395,8 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap, 
         }
 
         val doGap = {
-            useGap(distance, close, facingAway)
+            // Avoid turning 180° before eating by not forcing a retreat
+            useGap(distance, false, facingAway)
             gapsLeft--
             lastGap = now
             gapLockUntil = now + MIN_GAP_INTERVAL_MS
@@ -541,9 +542,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap, 
                 combo--
                 TimeUtils.setTimeout(fun () { tapping = false }, 300)
             } else if (n.contains("sword")) {
-                if (distance < 2f) {
-                    Mouse.rClick(RandomUtils.randomIntInRange(60, 90))
-                } else {
+                if (distance >= 2f) {
                     Combat.wTap(100)
                     tapping = true
                     TimeUtils.setTimeout(fun () { tapping = false }, 100)

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Gap.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Gap.kt
@@ -12,6 +12,7 @@ interface Gap {
     var lastGap: Long
 
     fun useGap(distance: Float, run: Boolean, facingAway: Boolean) {
+        if (Mouse.rClickDown) Mouse.rClickUp()
         lastGap = System.currentTimeMillis()
         fun gap() {
             Mouse.stopLeftAC()


### PR DESCRIPTION
## Summary
- release right-click before equipping golden apple
- remove automatic sword parry in OP duels
- avoid 180° turn before eating by skipping forced retreat

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c6a723ed4083298a3150a7de3e38a8