### PR TITLE
Fix flint and steel selection in OP mode

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Flint.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Flint.kt
@@ -22,7 +22,8 @@ interface Flint {
      */
     fun useFlint(distance: Float, after: () -> Unit = {}) {
         if (flintUses <= 0) return
-        if (!Inventory.setInvItem("flint_and_steel")) {
+        // Unlocalized name is "item.flintAndSteel" -> substring "flintandsteel"
+        if (!Inventory.setInvItem("flintandsteel")) {
             after()
             return
         }


### PR DESCRIPTION
## Summary
- correct flint and steel inventory lookup so OP bot actually equips and uses the item

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c47ad1f08329bb844640f479fab5