### PR TITLE
Add retreat behavior during gapple use

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -177,16 +177,23 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         }
         val hadAbsorption = player.isPotionActive(MCPotion.absorption)
 
-        retreating = true
-        Movement.stopForward()
-        Movement.startBackward()
-
         val ok = equipAndHoldRightClick(
             { equipAny("gap", "gapple", "apple", "golden_apple") },
             { isHoldingGap() },
             preMs, holdMs, /*returnSword=*/true
         )
         if (ok) {
+            if (preMs <= 0) {
+                retreating = true
+                Movement.stopForward()
+                Movement.startBackward()
+            } else {
+                TimeUtils.setTimeout({
+                    retreating = true
+                    Movement.stopForward()
+                    Movement.startBackward()
+                }, preMs)
+            }
             TimeUtils.setTimeout({
                 Movement.stopBackward()
                 if (!tapping) Movement.startForward()


### PR DESCRIPTION
## Summary
- Back off only while consuming golden apples in Combo duels
- In OP duels, step back, rod the opponent, then eat a golden apple while retreating

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c6ce8aae2483299a6c765ed4d084e9