### PR TITLE
Increase flint use range

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -229,7 +229,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
             if (!tapping) Movement.startForward()
             retreating = false
             // Fallback minimal : on essaie via helper (sélection interne) SANS tenir un 2e clic par-dessus
-            useGap(distance, distance < 2f, EntityUtils.entityFacingAway(player, target))
+            useGap(distance, distance < 4f, EntityUtils.entityFacingAway(player, target))
         }
         return ok
     }

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -664,7 +664,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap, 
                     !eatingGap && !takingPotion && now - lastPotion > 3500) {
 
                     if (gapsLeft > 0 && now >= gapLockUntil) {
-                        eatGoldenApple(distance, distance < 2f, EntityUtils.entityFacingAway(p, opp))
+                        eatGoldenApple(distance, distance < 4f, EntityUtils.entityFacingAway(p, opp))
                     } else if (regenPotsLeft > 0 && now - gameStartAt >= 120000 && now - lastRegenUse > 3500) {
                         // ===== 2e REGEN : cast aux pieds =====
                         feetSplash(regenDamage) {


### PR DESCRIPTION
## Summary
- increase distance threshold for gap-triggered flint and steel usage to 4 blocks

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : Unable to tunnel through proxy (403 Forbidden))*
- `./gradlew test --refresh-dependencies` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.7.10'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d1f058fc8329b93001e15b7b0c47