### PR TITLE
fix: maintain tracking when eating gapple in OP

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -417,12 +417,18 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
         Mouse.stopLeftAC()
         Mouse.setUsingProjectile(false)
 
-        useGap(distance, close, facingAway)
+        // Walk backwards while keeping the opponent in sight instead of
+        // performing a 180° turn via Mouse#setRunningAway.
+        Movement.stopForward()
+        Movement.startBackward()
+        useGap(distance, /*run=*/false, facingAway)
         gapsLeft--
         lastGap = now
         gapLockUntil = now + MIN_GAP_INTERVAL_MS
 
         waitUntilFinishedEating(maxWaitMs = 2400) {
+            Movement.stopBackward()
+            if (!tapping) Movement.startForward()
             eatingGap = false
             if (Mouse.rClickDown) Mouse.rClickUp()
             if (!Mouse.isUsingProjectile() && !Mouse.isUsingPotion()) {


### PR DESCRIPTION
## Summary
- avoid 180° turn when eating golden apple in OP mode by walking backwards while keeping target

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fbcdcc5c8329bbbb3dafa9422724