### PR TITLE
fix: keep tracking when eating gap

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -417,12 +417,22 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
         Mouse.stopLeftAC()
         Mouse.setUsingProjectile(false)
 
-        useGap(distance, close, facingAway)
+        val wasForward = Movement.forward()
+        if (close) {
+            Movement.stopForward()
+            Movement.startBackward()
+        }
+
+        useGap(distance, false, facingAway)
         gapsLeft--
         lastGap = now
         gapLockUntil = now + MIN_GAP_INTERVAL_MS
 
         waitUntilFinishedEating(maxWaitMs = 2400) {
+            if (close) {
+                Movement.stopBackward()
+                if (wasForward) Movement.startForward()
+            }
             eatingGap = false
             if (Mouse.rClickDown) Mouse.rClickUp()
             if (!Mouse.isUsingProjectile() && !Mouse.isUsingPotion()) {


### PR DESCRIPTION
## Summary
- avoid 180° turn when eating gaps in OP mode by backpedaling while still tracking

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fbcdcc5c8329bbbb3dafa9422724