### PR TITLE
fix: ensure OP bot eats golden apples

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -178,7 +178,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         val hadAbsorption = player.isPotionActive(MCPotion.absorption)
 
         val ok = equipAndHoldRightClick(
-            { equipAny("gap", "gapple", "apple", "golden_apple") },
+            { equipAny("gold", "gap", "gapple", "apple", "golden_apple") }, // recognise "gold" alias
             { isHoldingGap() },
             preMs, holdMs, /*returnSword=*/true
         )


### PR DESCRIPTION
## Summary
- broaden combo gapple lookup to recognise "gold" alias
- attempt to run tests

## Testing
- `./gradlew test` (fails: Unable to tunnel through proxy 403)


------
https://chatgpt.com/codex/tasks/task_e_68c6ffe658f48329a58a189eabf0b837