### PR TITLE
Tune OP bot gapple health thresholds

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -679,8 +679,11 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             val hbActive = now < hbActiveUntil
 
             // =====================  SOINS classiques (gap / regen tardive sur PV) =====================
-            if (((distance > 3f && p.health < 12) || p.health < 9) &&
-                combo < 2 && p.health <= opp.health) {
+            val recentRegen = now - lastRegenUse <= 25_000L
+            val gapThreshold = if (recentRegen) 8 else 10
+            val nearGapThreshold = if (recentRegen) gapThreshold else 9
+            val criticalHealth = p.health < gapThreshold
+            if (combo < 2 && (criticalHealth || (((distance > 3f && p.health < gapThreshold) || p.health < nearGapThreshold) && p.health <= opp.health))) {
                 if (!Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() &&
                     !eatingGap && !takingPotion && now - lastPotion > 3500) {
 


### PR DESCRIPTION
## Summary
- lower default gapple trigger to 10 HP
- delay gapple to 8 HP if regen potion used within last 25s

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c7169b193483299fd55d4043c5c54a