### PR TITLE
Adjust golden apple threshold for OP bot

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -679,8 +679,9 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             val hbActive = now < hbActiveUntil
 
             // =====================  SOINS classiques (gap / regen tardive sur PV) =====================
-            val criticalHealth = p.health < 10
-            if (combo < 2 && (criticalHealth || (((distance > 3f && p.health < 12) || p.health < 9) && p.health <= opp.health))) {
+            val recentRegen = now - lastRegenUse < 25_000L
+            val gapThreshold = if (recentRegen) 8f else 10f
+            if (combo < 2 && p.health < gapThreshold) {
                 if (!Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() &&
                     !eatingGap && !takingPotion && now - lastPotion > 3500) {
 


### PR DESCRIPTION
## Summary
- Decrease OP bot's golden apple usage threshold to 10 HP by default.
- Respect recent regeneration by delaying golden apple until 8 HP when a regen potion was used in last 25s.

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c71ab02e448329b1f1f4cdff31d245