### PR TITLE
fix: ensure OP bot eats golden apples

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -682,8 +682,9 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
 
             // =====================  SOINS classiques (gap / regen tardive sur PV) =====================
             val recentRegen = now - lastRegenUse < 25_000L
-            val gapThreshold = if (recentRegen) 8f else 10f
-            if (combo < 2 && p.health < gapThreshold) {
+            val currentHealth = p.health + p.absorptionAmount
+            val gapThreshold = if (recentRegen) 20f else 22f
+            if (combo < 2 && currentHealth < gapThreshold) {
                 if (!Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() &&
                     !eatingGap && !takingPotion && now - lastPotion > 3500) {
 


### PR DESCRIPTION
## Summary
- detect player health including absorption for OP duels

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c730eb09c48329bf892b8b009e8c5d