### PR TITLE
fix: ensure OP bot eats golden apples

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -682,8 +682,9 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
 
             // =====================  SOINS classiques (gap / regen tardive sur PV) =====================
             val recentRegen = now - lastRegenUse < 25_000L
+            val currentHealth = p.health + p.absorptionAmount
             val gapThreshold = if (recentRegen) 8f else 10f
-            if (combo < 2 && p.health < gapThreshold) {
+            if (combo < 2 && currentHealth < gapThreshold) {
                 if (!Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() &&
                     !eatingGap && !takingPotion && now - lastPotion > 3500) {
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Gap.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Gap.kt
@@ -16,7 +16,9 @@ interface Gap {
         lastGap = System.currentTimeMillis()
         fun gap() {
             Mouse.stopLeftAC()
-            if (Inventory.setInvItem("gold")) {
+            val equipped = listOf("gold", "gap", "gapple", "apple", "golden_apple")
+                .any { Inventory.setInvItem(it) }
+            if (equipped) {
                 ChatUtils.info("About to gap")
                 val r = RandomUtils.randomIntInRange(2100, 2200)
                 val equipDelay = RandomUtils.randomIntInRange(80, 130)


### PR DESCRIPTION
## Summary
- detect player health including absorption for OP duels
- restore original gap health thresholds to trigger healing at low total hearts
- recognize golden apples using multiple aliases so the bot can equip gaps reliably

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c730eb09c48329bf892b8b009e8c5d