### PR TITLE
Improve OP potion splash reliability

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -408,18 +408,26 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap, 
         takingPotion = true
         Mouse.stopTracking()
         Movement.stopJumping()
+        val player = mc.thePlayer
+        val opp = opponent()
+        if (player != null && opp != null) {
+            val distance = EntityUtils.getDistanceNoY(player, opp)
+            if (distance > 5f && Movement.forward()) {
+                Movement.stopForward()
+            }
+        }
         waitUntilOnGround(maxWaitMs = 420) {
             val down = pickDownwardPitch()
             setPitchInstant(down)
             TimeUtils.setTimeout({
-                useSplashPotion(damage, false, false)
+                useSplashPotion(damage, false, false, doubleClick = true)
                 if (Mouse.rClickDown) Mouse.rClickUp()
                 lastPotion = System.currentTimeMillis()
-                setPitchLock(down, lockMs = RandomUtils.randomIntInRange(130, 170))
+                setPitchLock(down, lockMs = RandomUtils.randomIntInRange(360, 440))
                 takingPotion = false
                 Mouse.startTracking()
                 onComplete?.invoke()
-            }, RandomUtils.randomIntInRange(80, 140))
+            }, RandomUtils.randomIntInRange(100, 160))
         }
     }
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Potion.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Potion.kt
@@ -12,7 +12,12 @@ interface Potion {
 
     var lastPotion: Long
 
-    fun useSplashPotion(damage: Int, run: Boolean, facingAway: Boolean) {
+    fun useSplashPotion(
+        damage: Int,
+        run: Boolean,
+        facingAway: Boolean,
+        doubleClick: Boolean = false
+    ) {
         lastPotion = System.currentTimeMillis()
         fun pot(dmg: Int) {
             Mouse.stopLeftAC()
@@ -26,11 +31,8 @@ interface Potion {
                 TimeUtils.setTimeout(fun() {
                     Mouse.setUsingPotion(true)
 
-                    TimeUtils.setTimeout(fun () {
-                        val r = RandomUtils.randomIntInRange(80, 120)
-                        Mouse.rClick(r)
-
-                        TimeUtils.setTimeout(fun () {
+                    fun finishAfter(delay: Int) {
+                        TimeUtils.setTimeout(fun() {
                             Mouse.setUsingPotion(false)
                             TimeUtils.setTimeout(fun() {
                                 Inventory.setInvItem("sword")
@@ -39,7 +41,26 @@ interface Potion {
                                     Mouse.setRunningAway(false)
                                 }, RandomUtils.randomIntInRange(500, 700))
                             }, RandomUtils.randomIntInRange(80, 120))
-                        }, r + RandomUtils.randomIntInRange(80, 120))
+                        }, delay)
+                    }
+
+                    TimeUtils.setTimeout(fun() {
+                        val firstHold = RandomUtils.randomIntInRange(80, 120)
+                        Mouse.rClick(firstHold)
+
+                        val afterFirst = firstHold + RandomUtils.randomIntInRange(80, 120)
+
+                        if (doubleClick) {
+                            val betweenClicks = RandomUtils.randomIntInRange(40, 70)
+                            TimeUtils.setTimeout(fun() {
+                                val secondHold = RandomUtils.randomIntInRange(70, 110)
+                                Mouse.rClick(secondHold)
+                                val afterSecond = secondHold + RandomUtils.randomIntInRange(80, 120)
+                                finishAfter(afterSecond)
+                            }, afterFirst + betweenClicks)
+                        } else {
+                            finishAfter(afterFirst)
+                        }
                     }, RandomUtils.randomIntInRange(100, 200))
                 }, RandomUtils.randomIntInRange(50, 100))
             }


### PR DESCRIPTION
## Summary
- add optional double-click behaviour to splash potion usage to improve throw reliability
- adjust OP feet splash routine to halt forward push when the opponent is far and keep the pitch locked longer
- trigger the feet splash sequence with the new double click support for consistent second speed/regen casts

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy for com.mojang:minecraft:1.8.9 download)*

------
https://chatgpt.com/codex/tasks/task_e_68cc646be4988329920ba81fcc0da971